### PR TITLE
Connect event info button to backend for volunteers

### DIFF
--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import styles from "@/styles/VolunteerEventsPage.module.css";
 import { AppEvent, MOCK_EVENTS, VolunteerStatus } from "@/data/events";
 
@@ -31,6 +32,8 @@ function EventCard({ event }: { event: AppEvent }) {
   const monthLabel = event.date.toLocaleString("en-US", { month: "long" });
   const dayNumber = event.date.getDate();
   const status = event.volunteerStatus ?? "none";
+  const router = useRouter();
+  const isMissingWaiver = status === "missing_waiver";
 
   return (
     <div className={`${styles.card} ${event.section === "upcoming" ? styles.cardHoverEnabled : ""}`}>
@@ -68,8 +71,15 @@ function EventCard({ event }: { event: AppEvent }) {
           <div className={styles.hoverText}>{event.school}</div>
 
           <div className={styles.hoverButtons}>
-            <button type="button" className={styles.hoverBtnLight}>
-              {status === "missing_waiver" ? "Sign Waiver" : "Event Info"}
+            <button
+              type="button"
+              className={styles.hoverBtnLight}
+              onClick={() => {
+                if (isMissingWaiver) return;
+                router.push(`/events/${event.id}`);
+              }}
+            >
+              {isMissingWaiver ? "Sign Waiver" : "Event Info"}
             </button>
 
             <button type="button" className={styles.hoverBtnDark}>


### PR DESCRIPTION
## Developer: Lorinc Heutchy

Closes #43 

### Pull Request Summary

Volunteer's "Event Info" button being clicked now routes to that event's page '/events/[eventId]'

### Modifications

src/components/VolunteerEventsPage.tsx
  - Added `useRouter`
  - Added conditional button behavior in `EventCard`:
    - If waiver is not missing, clicking the button routes to `/events/${event.id}`

### Testing Considerations

Verified clicking the Event Info button links to the event page
Ran npm lint successfully

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://github.com/user-attachments/assets/e5449058-ead9-42b8-bf26-5e20d347ac9e

