### PR TITLE
Implement My Account edit flow

### DIFF
--- a/src/app/account/delete/page.tsx
+++ b/src/app/account/delete/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import NavBarWrapper from "@/components/NavbarWrapper";
+import styles from "@/styles/Account.module.css";
+
+export default function DeleteAccountPage() {
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    router.push("/account/delete/success");
+  };
+
+  return (
+    <div>
+      <NavBarWrapper />
+
+      <main className={styles.page}>
+        <div className={styles.inner}>
+          <div className={styles.backLinkWrap}>
+            <Link href="/account" className={styles.backLink}>
+              ← Back to My Account
+            </Link>
+          </div>
+
+          <div className={styles.deleteCard}>
+            <h2 className={styles.deleteCardTitle}>Are you sure you want to delete your account?</h2>
+
+            <p className={styles.deleteCardText}>
+              This will permanently delete your account and associated data. This action cannot be undone.
+            </p>
+
+            <div className={styles.deleteCardButtons}>
+              <Link href="/account">
+                <button type="button" className={styles.cancelButton}>
+                  Cancel
+                </button>
+              </Link>
+
+              <button type="button" className={styles.deleteButton} onClick={handleDelete}>
+                Delete my account
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/account/delete/success/page.tsx
+++ b/src/app/account/delete/success/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import NavBarWrapper from "@/components/NavbarWrapper";
+import styles from "@/styles/Account.module.css";
+
+export default function DeleteSuccessPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push("/login");
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <div>
+      <NavBarWrapper />
+
+      <main className={styles.page}>
+        <div className={styles.inner}>
+          <div className={styles.deleteCard}>
+            <h2 className={styles.successTitle}>Account deleted</h2>
+
+            <p className={styles.successText}>
+              Your profile and associated account data have been permanently removed. You will now be signed out.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,31 +1,215 @@
 "use client";
 
+import { ChangeEvent, FormEvent, useState } from "react";
+import Link from "next/link";
 import { useClerk } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import NavBarWrapper from "@/components/NavbarWrapper";
+import styles from "@/styles/Account.module.css";
+
+type NotificationOption = "Text" | "Email" | "Both" | "None";
+
+interface AccountFormData {
+  firstName: string;
+  lastName: string;
+  phone: string;
+  dob: string;
+  email: string;
+  password: string;
+  shiftUpdates: NotificationOption;
+  directMessages: NotificationOption;
+}
 
 export default function AccountPage() {
   const { signOut } = useClerk();
   const router = useRouter();
+  const [isEditing, setIsEditing] = useState(false);
+
+  const [formData, setFormData] = useState<AccountFormData>({
+    firstName: "",
+    lastName: "",
+    phone: "(XXX) XXX-XXXX",
+    dob: "XX/XX/XXXX",
+    email: "example@email.com",
+    password: "****************",
+    shiftUpdates: "Text",
+    directMessages: "Both",
+  });
 
   async function handleLogout() {
     await signOut();
     router.push("/login");
   }
 
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSave = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
   return (
     <div>
       <NavBarWrapper />
-      <main className="p-8 font-lora">
-        <h1 className="text-4xl font-bold">My Account</h1>
-        <div className="mt-8">
-          <button
-            type="button"
-            onClick={handleLogout}
-            className="rounded-full border border-[#d9a7a7] bg-[#f8d7d7] px-6 py-2 font-semibold text-black transition hover:brightness-95 active:brightness-90"
-          >
-            Log Out
-          </button>
+
+      <main className={styles.page}>
+        <div className={styles.inner}>
+          <h1 className={styles.title}>My Account</h1>
+
+          <form className={styles.form} onSubmit={handleSave}>
+            <div className={styles.row}>
+              <div className={styles.fieldGroup}>
+                <label className={styles.label}>First Name</label>
+                <input
+                  className={styles.input}
+                  type="text"
+                  name="firstName"
+                  value={formData.firstName}
+                  onChange={handleChange}
+                  disabled={!isEditing}
+                  placeholder="First Name"
+                />
+              </div>
+
+              <div className={styles.fieldGroup}>
+                <label className={styles.label}>Last Name</label>
+                <input
+                  className={styles.input}
+                  type="text"
+                  name="lastName"
+                  value={formData.lastName}
+                  onChange={handleChange}
+                  disabled={!isEditing}
+                  placeholder="Last Name"
+                />
+              </div>
+            </div>
+
+            <div className={styles.shortRow}>
+              <div className={styles.fieldGroup}>
+                <label className={styles.label}>Phone Number</label>
+                <input
+                  className={styles.input}
+                  type="text"
+                  name="phone"
+                  value={formData.phone}
+                  onChange={handleChange}
+                  disabled={!isEditing}
+                />
+              </div>
+
+              <div className={styles.compactFieldGroup}>
+                <label className={styles.label}>Date of Birth</label>
+                <input
+                  className={styles.input}
+                  type="text"
+                  name="dob"
+                  value={formData.dob}
+                  onChange={handleChange}
+                  disabled={!isEditing}
+                />
+              </div>
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Email Address</label>
+              <input
+                className={styles.input}
+                type="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                disabled={!isEditing}
+              />
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Create New Password</label>
+              <input
+                className={styles.input}
+                type="text"
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+                disabled={!isEditing}
+              />
+            </div>
+
+            <h2 className={styles.sectionHeading}>Notification Preference</h2>
+
+            <div className={styles.preferenceGrid}>
+              <label className={styles.preferenceLabel}>Shift Updates</label>
+              <select
+                className={styles.preferenceSelect}
+                name="shiftUpdates"
+                value={formData.shiftUpdates}
+                onChange={handleChange}
+                disabled={!isEditing}
+              >
+                <option value="Text">Text</option>
+                <option value="Email">Email</option>
+                <option value="Both">Both</option>
+                <option value="None">None</option>
+              </select>
+
+              <label className={styles.preferenceLabel}>Direct Messages</label>
+              <select
+                className={styles.preferenceSelect}
+                name="directMessages"
+                value={formData.directMessages}
+                onChange={handleChange}
+                disabled={!isEditing}
+              >
+                <option value="Text">Text</option>
+                <option value="Email">Email</option>
+                <option value="Both">Both</option>
+                <option value="None">None</option>
+              </select>
+            </div>
+
+            {!isEditing ? (
+              <div className={styles.actionsSingle}>
+                <button type="button" className={styles.editButton} onClick={() => setIsEditing(true)}>
+                  Edit Information
+                </button>
+              </div>
+            ) : (
+              <div className={styles.actionsDual}>
+                <button type="button" className={styles.cancelButton} onClick={handleCancel}>
+                  Cancel
+                </button>
+                <button type="submit" className={styles.saveButton}>
+                  Save
+                </button>
+              </div>
+            )}
+          </form>
+
+          <section className={styles.deleteSection}>
+            <h2 className={styles.deleteTitle}>Delete Account</h2>
+            <p className={styles.deleteText}>
+              Permanently delete your account and associated data. This action cannot be undone.
+            </p>
+
+            <div className={styles.deleteButtonWrap}>
+              <Link href="/account/delete">
+                <button type="button" className={styles.deleteButton}>
+                  Delete my account
+                </button>
+              </Link>
+            </div>
+          </section>
         </div>
       </main>
     </div>

--- a/src/styles/Account.module.css
+++ b/src/styles/Account.module.css
@@ -1,0 +1,364 @@
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 18px 32px 32px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: #111;
+
+  transform: scale(1.2);
+  transform-origin: top center;
+}
+
+.inner {
+  width: 100%;
+  max-width: 410px;
+  margin: 0 auto;
+}
+
+.title {
+  text-align: center;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin: 4px 0 12px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.shortRow {
+  display: grid;
+  grid-template-columns: 1fr 92px;
+  gap: 12px;
+}
+
+.fieldGroup,
+.compactFieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.label {
+  font-size: 0.54rem;
+  font-weight: 400;
+  line-height: 1.1;
+  padding-left: 1px;
+}
+
+.input,
+.select {
+  height: 22px;
+  border: 1px solid #6f93de;
+  border-radius: 4px;
+  background: #fff;
+  padding: 3px 8px;
+  font-size: 0.58rem;
+  color: #555;
+  outline: none;
+}
+
+.input:disabled,
+.select:disabled {
+  opacity: 1;
+  background: #fff;
+  color: #666;
+  cursor: default;
+}
+
+.sectionHeading {
+  margin-top: 4px;
+  margin-bottom: 1px;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.preferenceGrid {
+  display: grid;
+  grid-template-columns: auto 62px;
+  gap: 8px 8px;
+  align-items: center;
+  width: fit-content;
+  margin-left: 20px;
+}
+
+.preferenceLabel {
+  font-size: 0.54rem;
+  line-height: 1;
+}
+
+.preferenceSelect {
+  width: 54px;
+  height: 17px;
+  border: 1px solid #6f93de;
+  border-radius: 999px;
+  background: #fff;
+  font-size: 0.5rem;
+  padding: 0 5px;
+  color: #333;
+}
+
+.actionsSingle {
+  margin-top: 4px;
+  display: flex;
+  justify-content: center;
+}
+
+.actionsDual {
+  margin-top: 4px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.editButton,
+.saveButton,
+.cancelButton {
+  min-width: 94px;
+  height: 21px;
+  border-radius: 6px;
+  font-size: 0.58rem;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.editButton,
+.saveButton {
+  background: #cfe7bb;
+  border: 1px solid #7d9f69;
+  color: #355235;
+}
+
+.cancelButton {
+  background: #efefef;
+  border: 1px solid #bdbdbd;
+  color: #444;
+}
+
+.deleteSection {
+  margin-top: 8px;
+}
+
+.deleteTitle {
+  font-size: 0.82rem;
+  font-weight: 700;
+  margin: 0 0 1px;
+}
+
+.deleteText {
+  font-size: 0.39rem;
+  line-height: 1.15;
+  color: #555;
+  text-decoration: underline;
+  margin: 0 0 8px;
+  max-width: 250px;
+}
+
+.deleteButton {
+  min-width: 110px;
+  height: 21px;
+  border: 1px solid #7d1717;
+  border-radius: 6px;
+  background: #bc2b24;
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.deleteButtonWrap {
+  display: flex;
+  justify-content: center;
+}
+
+.logoutWrap {
+  margin-top: 14px;
+}
+
+.logoutButton {
+  min-width: 104px;
+  height: 26px;
+  border-radius: 999px;
+  border: 1px solid #d9a7a7;
+  background: #f2d8d8;
+  color: #111;
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.backLinkWrap {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 14px;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 112px;
+  height: 22px;
+  border-radius: 6px;
+  background: #eef7ea;
+  border: 1px solid #b7d0ae;
+  color: #6f8c69;
+  text-decoration: none;
+  font-size: 0.58rem;
+  font-weight: 600;
+}
+
+.deleteCard {
+  margin: 42px auto 0;
+  max-width: 300px;
+  border: 1px solid #84a3de;
+  border-radius: 4px;
+  background: #fbfcff;
+  padding: 20px 18px;
+  text-align: center;
+}
+
+.deleteCardTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 10px;
+}
+
+.deleteCardText {
+  max-width: 210px;
+  margin: 0 auto 14px;
+  font-size: 0.62rem;
+  line-height: 1.3;
+  color: #333;
+}
+
+.deleteCardButtons {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  align-items: center; /* <-- THIS FIXES IT */
+}
+
+.successTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #c83030;
+  margin-bottom: 10px;
+}
+
+.successText {
+  max-width: 220px;
+  margin: 0 auto;
+  font-size: 0.62rem;
+  line-height: 1.3;
+  color: #333;
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 14px 14px 28px;
+  }
+
+  .inner {
+    max-width: 170px;
+  }
+
+  .title {
+    font-size: 1.2rem;
+    margin-bottom: 10px;
+  }
+
+  .row,
+  .shortRow {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .input,
+  .select {
+    height: 20px;
+    font-size: 0.5rem;
+    padding: 3px 6px;
+  }
+
+  .label,
+  .preferenceLabel {
+    font-size: 0.42rem;
+  }
+
+  .sectionHeading {
+    font-size: 0.55rem;
+  }
+
+  .preferenceGrid {
+    grid-template-columns: auto 48px;
+    gap: 6px 6px;
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .preferenceSelect {
+    width: 48px;
+    height: 16px;
+    font-size: 0.42rem;
+  }
+
+  .actionsSingle,
+  .actionsDual {
+    justify-content: flex-start;
+  }
+
+  .editButton,
+  .saveButton,
+  .cancelButton,
+  .deleteButton {
+    min-width: 88px;
+    height: 18px;
+    font-size: 0.46rem;
+  }
+
+  .deleteTitle {
+    font-size: 0.72rem;
+  }
+
+  .deleteText {
+    font-size: 0.35rem;
+    max-width: 140px;
+  }
+
+  .deleteButtonWrap {
+    padding-left: 0;
+  }
+
+  .backLink {
+    min-width: 96px;
+    font-size: 0.45rem;
+    height: 18px;
+  }
+
+  .deleteCard {
+    max-width: 150px;
+    padding: 14px 10px;
+    margin-top: 16px;
+  }
+
+  .deleteCardTitle,
+  .successTitle {
+    font-size: 0.72rem;
+  }
+
+  .deleteCardText,
+  .successText {
+    font-size: 0.42rem;
+  }
+}


### PR DESCRIPTION
## Developer: Amogh Arora

Closes #61

### Pull Request Summary

Implemented the volunteer My Account flow based on the provided Figma wireframes. This includes the default account page, edit state on the same page, delete account confirmation page, and delete success page. Added scoped styling through `Account.module.css` so the new UI does not affect global styles.

### Modifications
- `src/app/account/page.tsx`
  - Expanded the existing account page into the full My Account flow
  - Added form fields for first name, last name, phone number, date of birth, email, password, and notification preferences
  - Added edit state behavior with `Edit Information`, `Cancel`, and `Save`
  - Added Delete Account section with navigation to the delete confirmation page
  - Kept Clerk integration in the page setup

- `src/app/account/delete/page.tsx`
  - Created the delete confirmation page
  - Added back navigation to My Account
  - Added confirmation card with Cancel and Delete actions

- `src/app/account/delete/success/page.tsx`
  - Created the account deleted success page
  - Added success confirmation message
  - Redirects the user to the login page after success

- `src/styles/Account.module.css`
  - Added scoped styling for all account-related pages
  - Styled desktop and mobile layouts for the account page, delete confirmation page, and success page
  - Tuned spacing, sizing, alignment, and button styles to closely match the Figma wireframes

### Testing Considerations

Tested the following manually in the browser:

- Navigating to `/account` from the My Account tab
- Default My Account page layout renders correctly
- Clicking `Edit Information` switches to the edit state
- Clicking `Cancel` returns to the default state
- Clicking `Save` returns to the default state
- Clicking `Delete my account` routes to `/account/delete`
- Delete confirmation page renders correctly
- Clicking `Cancel` on the delete page returns to `/account`
- Clicking `Delete my account` on the confirmation page routes to `/account/delete/success`
- Success page renders correctly and redirects to `/login`

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="1918" height="869" alt="image" src="https://github.com/user-attachments/assets/b7c0d96a-228c-4b9a-9520-db7093fecf5b" />
<img width="1915" height="871" alt="image" src="https://github.com/user-attachments/assets/21304a83-f432-4f81-b8e0-1699160ae8c2" />
<img width="1916" height="859" alt="image" src="https://github.com/user-attachments/assets/d3692d68-ee18-4ed0-9a69-6003de2c6470" />
<img width="1911" height="874" alt="image" src="https://github.com/user-attachments/assets/b58b708e-234f-4c95-87ea-e35e1d41e204" />

{put screenshots of your change, or even better a screencast displaying the functionality}
