### PR TITLE
Implement mobile report frontend

### DIFF
--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -17,29 +17,56 @@ type TableMap = Record<string, Table>;
 const schoolData: TableMap = {
   entry1: { name: "School 1", events: 3, volunteers: 15, hours: 40 },
   entry2: { name: "School 2", events: 2, volunteers: 17, hours: 28 },
-  entry3: { name: "School 3", events: 4, volunteers: 18, hours: 20 },
-  entry4: { name: "School 4", events: 2, volunteers: 19, hours: 15 },
+  entry3: { name: "School 3", events: 4, volunteers: 23, hours: 52 },
+  entry4: { name: "School 4", events: 2, volunteers: 8, hours: 28 },
+  entry5: { name: "School 5", events: 1, volunteers: 17, hours: 20 },
 };
 
 const organizationData: TableMap = {
   entry1: { name: "Company Name 1", events: 3, volunteers: 15, hours: 40 },
   entry2: { name: "Company Name 2", events: 2, volunteers: 17, hours: 28 },
-  entry3: { name: "Company Name 3", events: 4, volunteers: 18, hours: 20 },
-  entry4: { name: "Company Name 4", events: 2, volunteers: 19, hours: 15 },
+  entry3: { name: "Company Name 3", events: 4, volunteers: 23, hours: 52 },
+  entry4: { name: "Company Name 4", events: 2, volunteers: 8, hours: 28 },
+  entry5: { name: "Company Name 5", events: 1, volunteers: 17, hours: 20 },
 };
 
 export default function WorkdayReport() {
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const [startDate, setStartDate] = useState("2025-01-01");
+  const [endDate, setEndDate] = useState("2025-12-31");
 
   return (
     <div>
-      <NavBarWrapper />
+      <div className={styles.desktopNav}>
+        <NavBarWrapper />
+      </div>
+
       <div className={styles.container}>
+        <div className={styles.mobileHeader}>
+          <div className={styles.mobileHeaderBar}>
+            <div className={styles.mobileBrand}>GARDEN WORKDAY EVENT</div>
+
+            <button type="button" className={styles.mobileMenuButton} aria-label="Open menu">
+              <span className={styles.mobileMenuLine} />
+              <span className={styles.mobileMenuLine} />
+              <span className={styles.mobileMenuLine} />
+            </button>
+          </div>
+        </div>
+
         <div className={styles.topBar}>
-          <div className={styles.headerTitle}>Garden Workday Report</div>
+          <div className={styles.headerTitleRow}>
+            <div className={styles.headerTitle}>Garden Workday Report</div>
+
+            <button type="button" className={styles.mobilePdfButton}>
+              PDF
+            </button>
+          </div>
 
           <div className={styles.dateFilter}>
+            <button type="button" className={styles.desktopPdfButton}>
+              PDF
+            </button>
+
             <input
               type="date"
               value={startDate}
@@ -53,28 +80,30 @@ export default function WorkdayReport() {
               onChange={(e) => setEndDate(e.target.value)}
               className={styles.dateInput}
             />
-            <button className={styles.arrowButton}>→</button>
+            <button type="button" className={styles.arrowButton}>
+              →
+            </button>
           </div>
         </div>
 
         <div className={styles.summaryRow}>
           <div className={styles.summaryBox}>
             <div className={styles.summaryItem}>
-              <span className={styles.summaryValueBold}>120 Volunteers</span>
+              <span className={styles.summaryValueBold}>54 volunteers</span>
             </div>
 
             <div className={styles.summaryItem}>
-              <span className={styles.summaryValue}>45 Returning</span>
+              <span className={styles.summaryValue}>12 returning</span>
             </div>
           </div>
 
           <div className={styles.summaryBox}>
             <div className={styles.summaryItem}>
-              <span className={styles.summaryValueBold}>22 Events</span>
+              <span className={styles.summaryValueBold}>12 events</span>
             </div>
 
             <div className={styles.summaryItem}>
-              <span className={styles.summaryValue}>310 Hours</span>
+              <span className={styles.summaryValue}>120 hours</span>
             </div>
           </div>
         </div>

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -43,7 +43,7 @@ export default function WorkdayReport() {
       <div className={styles.container}>
         <div className={styles.mobileHeader}>
           <div className={styles.mobileHeaderBar}>
-            <div className={styles.mobileBrand}>GARDEN WORKDAY EVENT</div>
+            <div className={styles.mobileBrand}>GARDEN WORKDAY EVENTS</div>
 
             <button type="button" className={styles.mobileMenuButton} aria-label="Open menu">
               <span className={styles.mobileMenuLine} />

--- a/src/components/WorkdayReportCard.tsx
+++ b/src/components/WorkdayReportCard.tsx
@@ -26,7 +26,9 @@ export default function WorkdayReportCard({ tableData }: Props) {
 
               <td className={styles.infoCell}>
                 <div className={styles.infoGroup}>
-                  <span>{data.events} events</span>
+                  <span>
+                    {data.events} {data.events === 1 ? "event" : "events"}
+                  </span>
                   <span>{data.volunteers} volunteers</span>
                   <span>{data.hours} hrs</span>
                 </div>

--- a/src/styles/WorkdayReport.module.css
+++ b/src/styles/WorkdayReport.module.css
@@ -4,6 +4,15 @@
   width: 100%;
   margin: 2%;
   font-family: "Lora", serif;
+  box-sizing: border-box;
+}
+
+.desktopNav {
+  display: block;
+}
+
+.mobileHeader {
+  display: none;
 }
 
 .topBar {
@@ -12,6 +21,12 @@
   align-items: center;
   margin-bottom: 25px;
   width: 95%;
+  gap: 16px;
+}
+
+.headerTitleRow {
+  display: block;
+  width: auto;
 }
 
 .headerTitle {
@@ -25,33 +40,86 @@
   margin: 30px 0 10px;
 }
 
+.mobilePdfButton {
+  display: none;
+}
+
+.desktopPdfButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 37px;
+  margin-right: 10px;
+  border: none;
+  color: #ffffff;
+  background: #527abe;
+  font-family: "Lora", serif;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+  clip-path: polygon(0 0, 72% 0, 100% 24%, 100% 100%, 0 100%);
+  cursor: default;
+  flex-shrink: 0;
+}
+
 .dateFilter {
   display: flex;
   align-items: center;
-  gap: 10px;
-  border: 1px solid #527abe;
-  border-radius: 14px;
-  padding: 1px;
-  background: #f9fbff;
+  gap: 0;
+  background: transparent;
 }
 
 .dateInput {
+  height: 32px;
   padding: 6px 10px;
   font-size: 14px;
-  border-radius: 20px;
+  font-family: "Lora", serif;
+  font-weight: 700;
+  border: 1px solid #527abe;
+  border-radius: 0;
+  background: #f9fbff;
+  box-sizing: border-box;
+}
+
+.dateFilter > .dateInput:first-of-type {
+  border-radius: 5px 0 0 5px;
+  border-right: none;
+}
+
+.dateFilter > .dateInput:last-of-type {
+  border-left: none;
 }
 
 .toText {
-  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 10px;
+  font-family: "Lora", serif;
+  font-size: 14px;
+  font-weight: 700;
+  background: #ffffff;
+  border-top: 1px solid #527abe;
+  border-bottom: 1px solid #527abe;
+  border-left: 1px solid #527abe;
+  border-right: 1px solid #527abe;
 }
 
 .arrowButton {
+  height: 32px;
+  min-width: 37px;
   background: #dcf9c9;
   color: #307433;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 10px;
-  cursor: pointer;
+  border: 1px solid #307433;
+  border-left: none;
+  padding: 0 12px;
+  border-radius: 0 10px 10px 0;
+  cursor: default;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .card {
@@ -72,7 +140,6 @@
   height: 55px;
 }
 
-/* Alternating rows */
 .rowLight {
   background-color: #e8f1ff;
 }
@@ -85,7 +152,7 @@
   padding-left: 20px;
   font-size: 20px;
   font-weight: 700;
-  width: 1%; /* forces shrink to content */
+  width: 1%;
   white-space: nowrap;
 }
 
@@ -102,6 +169,15 @@
   font-weight: 600;
   color: #666666;
   white-space: nowrap;
+}
+
+.infoGroup span {
+  background: transparent;
+  border: none;
+  padding: 0;
+  min-height: 0;
+  color: inherit;
+  font: inherit;
 }
 
 .summaryRow {
@@ -128,16 +204,331 @@
 }
 
 .summaryValue {
-  font-size: 28px;
-  font-weight: 700;
   font-size: 16px;
   font-weight: 600;
-  color: #444;
+  color: #444444;
 }
 
 .summaryValueBold {
-  font-size: 28px;
-  font-weight: 700;
   font-size: 16px;
-  font-weight: 600;
+  font-weight: 700;
+  color: #000000;
+}
+
+@media (max-width: 768px) {
+  .desktopNav {
+    display: none;
+  }
+
+  .mobileHeader {
+    display: block;
+    width: 100%;
+    margin-bottom: 12px;
+  }
+
+  .mobileHeaderBar {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 33px;
+    width: 100%;
+  }
+
+  .mobileBrand {
+    width: 100%;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 700;
+    color: #000000;
+    font-family: "Lora", serif;
+    line-height: 1;
+    padding: 0 40px;
+    box-sizing: border-box;
+  }
+
+  .mobileMenuButton {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 33px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    cursor: default;
+  }
+
+  .mobileMenuLine {
+    width: 24px;
+    height: 2px;
+    background: #000000;
+    display: block;
+    border-radius: 2px;
+  }
+
+  .container {
+    margin: 0;
+    width: 100%;
+    padding: 10px 17px;
+    box-sizing: border-box;
+  }
+
+  .topBar {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  .headerTitleRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .headerTitle {
+    font-size: 25px;
+    font-weight: 700;
+    line-height: 1;
+    color: #000000;
+  }
+
+  .desktopPdfButton {
+    display: none;
+  }
+
+  .mobilePdfButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 37px;
+    border: none;
+    color: #ffffff;
+    background: #527abe;
+    font-family: "Lora", serif;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0;
+    clip-path: polygon(0 0, 72% 0, 100% 24%, 100% 100%, 0 100%);
+    cursor: default;
+    flex-shrink: 0;
+  }
+
+  .dateFilter {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40px minmax(0, 1fr) 48px;
+    align-items: stretch;
+    gap: 0;
+    padding: 0;
+    border: 1px solid #527abe;
+    border-radius: 10px;
+    background: #ffffff;
+    overflow: hidden;
+  }
+
+  .dateInput {
+    width: 100%;
+    min-width: 0;
+    height: 46px;
+    padding: 10px 6px;
+    border: none;
+    border-radius: 0;
+    font-family: "Lora", serif;
+    font-size: clamp(12px, 4.2vw, 18px);
+    font-weight: 700;
+    line-height: 1;
+    color: #000000;
+    background: #f9fbff;
+    text-align: center;
+    box-sizing: border-box;
+    appearance: none;
+    -webkit-appearance: none;
+  }
+
+  .dateFilter > .dateInput:first-of-type {
+    border-right: 1px solid #527abe;
+  }
+
+  .dateFilter > .dateInput:last-of-type {
+    border-left: none;
+  }
+
+  .dateInput::-webkit-calendar-picker-indicator {
+    opacity: 0;
+    width: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toText {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border-top: none;
+    border-bottom: none;
+    border-right: 1px solid #527abe;
+    font-family: "Lora", serif;
+    font-size: clamp(12px, 4.2vw, 18px);
+    font-weight: 700;
+    color: #000000;
+    background: #ffffff;
+    text-align: center;
+  }
+
+  .arrowButton {
+    width: 48px;
+    min-width: 48px;
+    height: 46px;
+    border-top: none;
+    border-right: none;
+    border-bottom: none;
+    border-left: 1px solid #307433;
+    border-radius: 0 10px 10px 0;
+    background: #dcf9c9;
+    color: #307433;
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0;
+    cursor: default;
+  }
+
+  .summaryRow {
+    width: 100%;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .summaryBox {
+    width: 100%;
+    min-height: 48px;
+    padding: 10px;
+    border-radius: 5px;
+    border: 1px solid #527abe;
+    background: #eff4fe;
+    box-sizing: border-box;
+  }
+
+  .summaryValueBold {
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1;
+    color: #000000;
+  }
+
+  .summaryValue {
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1;
+    color: #7d7d7d;
+  }
+
+  .subTitle {
+    font-size: 25px;
+    font-weight: 700;
+    line-height: 1;
+    margin: 16px 0;
+    color: #000000;
+  }
+
+  .card {
+    width: 100%;
+    border: 1px solid #527abe;
+    border-radius: 5px;
+    background: #eff4fe;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  .table,
+  .table tbody {
+    display: block;
+    width: 100%;
+  }
+
+  .table tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .table td {
+    box-sizing: border-box;
+  }
+
+  .row {
+    min-height: 104px;
+    height: auto;
+    padding: 14px 12px 14px 10px;
+  }
+
+  .nameCell {
+    display: flex;
+    align-items: center;
+    align-self: center;
+    width: auto;
+    min-width: 0;
+    padding-left: 0;
+    margin-bottom: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: #000000;
+    line-height: 1.1;
+    white-space: nowrap;
+  }
+
+  .infoCell {
+    width: auto;
+    padding-right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    justify-self: end;
+    align-self: center;
+  }
+
+  .infoGroup {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+    white-space: normal;
+    font-size: 16px;
+    font-weight: 600;
+    color: #759982;
+  }
+
+  .infoGroup span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    padding: 4px 10px;
+    border-radius: 5px;
+    border: 1px solid #447544;
+    background: rgba(255, 255, 255, 0.5);
+    font-family: "Lora", serif;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1;
+    color: #759982;
+  }
 }


### PR DESCRIPTION
## Developer: {Full Name}

Closes #{ISSUE NUMBER HERE}

Implemented the mobile frontend for the Garden Workday Report page while preserving the existing desktop layout.

{Describe the purpose of your pull request}

### Modifications

- Added a mobile-specific report header and PDF button styling

- Updated the report page layout to better match the mobile Figma design

- Adjusted the date filter styling for desktop and mobile views

- Improved responsive styling for the summary boxes and report cards

- Updated the school and organization rows so mobile content displays more cleanly and completely


### Testing Considerations

I've tested out the responsiveness of the mobile layout on various mobile, iPad, and desktop screen sizes. You can test it out on any screen size just to be sure.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1919" height="915" alt="image" src="https://github.com/user-attachments/assets/3dba31a5-20b0-4c0f-a815-edfab9a9ff32" />
<img width="1072" height="924" alt="image" src="https://github.com/user-attachments/assets/0af28434-39bc-46bb-9e83-c4d8902d18d2" />
<img width="1059" height="893" alt="image" src="https://github.com/user-attachments/assets/c2a79cb1-4260-4723-983e-cf240d17d74f" />

