### PR TITLE
Add learn more + mobile homepage frontend

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { BookOpen, ChevronLeft, ChevronRight, ChevronsUpDown, House, Leaf, Shovel, Sprout } from "lucide-react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { Button } from "@mui/material";
 import VolunteerEventCard from "@/components/VolunteerEventCard";
 import styles from "@/styles/VolunteerEventsPage.module.css";
+import calendarStyles from "@/styles/CalendarPage.module.css";
 import { MOCK_EVENTS } from "@/data/events";
 import NavBarWrapper from "../../components/NavbarWrapper";
 
@@ -23,6 +24,7 @@ export default function CalendarPage() {
   const [viewDate, setViewDate] = useState(new Date());
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [learnMoreOpen, setLearnMoreOpen] = useState(false);
   const today = new Date();
 
   useEffect(() => {
@@ -84,22 +86,68 @@ export default function CalendarPage() {
   };
 
   const upcomingCardEvents = MOCK_EVENTS.filter((event) => event.section === "upcoming");
+  const responsibilities = [
+    { label: "Planting", Icon: Leaf },
+    { label: "Building Plant Beds", Icon: House },
+    { label: "Weeding", Icon: Sprout },
+    { label: "Spreading Mulch & Woodchips", Icon: Shovel },
+    { label: "Creating Garden Art", Icon: BookOpen },
+  ];
 
   return (
     <div>
       <NavBarWrapper />
-      <div className="p-8 font-lora">
-        <div className="text-4xl font-bold">Upcoming Events</div>
+      <div className={calendarStyles.page}>
+        <h1 className={calendarStyles.pageTitle}>Upcoming Events</h1>
 
-        <div className={styles.row}>
+        <div className={`${styles.row} ${calendarStyles.eventsRow}`}>
           {upcomingCardEvents.map((event) => (
             <VolunteerEventCard key={event.id} event={event} />
           ))}
         </div>
 
-        <div className="flex justify-between items-center mb-6">
-          <div className="flex items-center gap-4">
-            <div className="flex gap-2">
+        <section className={calendarStyles.responsibilitiesSection}>
+          <h2 className={calendarStyles.responsibilitiesTitle}>Garden Workday Responsibilities</h2>
+          <div className={calendarStyles.responsibilitiesGrid}>
+            {responsibilities.map(({ label, Icon }) => (
+              <div key={label} className={calendarStyles.responsibilityItem}>
+                <Icon size={44} className={calendarStyles.responsibilityIcon} aria-hidden="true" />
+                <span className={calendarStyles.responsibilityLabel}>{label}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={calendarStyles.learnMoreSection}>
+          <button
+            type="button"
+            className={calendarStyles.learnMoreButton}
+            onClick={() => setLearnMoreOpen((open) => !open)}
+            aria-expanded={learnMoreOpen}
+          >
+            <span>LEARN MORE</span>
+            <ChevronsUpDown size={14} className={calendarStyles.learnMoreIcon} aria-hidden="true" />
+          </button>
+
+          {learnMoreOpen ? (
+            <div className={calendarStyles.learnMoreContent}>
+              <p>
+                If you are interested in joining for a Garden Workday, please fill out our Volunteer Waiver which will
+                be sent upon registration. At the day and time of the event, you will enter at the school front office
+                and the staff will direct you to the garden. Please bring a hat, sunscreen, water, and wear closed-toed
+                shoes.
+              </p>
+              <p>
+                Workdays are weather dependent - it&apos;s always a good rule of thumb to call the office ahead of time
+                to ensure that the event is a go.
+              </p>
+            </div>
+          ) : null}
+        </section>
+
+        <div className={calendarStyles.controlsRow}>
+          <div className={calendarStyles.controlsLeft}>
+            <div className={calendarStyles.arrowGroup}>
               <button onClick={handlePrev} className="hover:opacity-70 transition-opacity">
                 <ChevronLeft size={40} color="#BEBEBE" />
               </button>
@@ -108,27 +156,23 @@ export default function CalendarPage() {
               </button>
             </div>
 
-            <h2 className="text-2xl font-bold">
+            <h2 className={calendarStyles.monthLabel}>
               {viewDate.toLocaleString("default", { month: "long", year: "numeric" })}
             </h2>
           </div>
 
-          <div>
-            <Button className="hover:opacity-70 transition-opacity" variant="outlined" onClick={handleReset}>
+          <div className={calendarStyles.todayWrap}>
+            <Button className={calendarStyles.todayButton} variant="outlined" onClick={handleReset}>
               Today
             </Button>
           </div>
 
-          <div className="w-[291px] h-[50px] flex-shrink-0">
-            <input
-              type="text"
-              placeholder="Search"
-              className="w-full h-full border-none rounded-full bg-[#D1E3F0] px-6 text-xl font-bold text-black placeholder:text-black placeholder:opacity-100 focus:outline-none"
-            />
+          <div className={calendarStyles.searchBox}>
+            <input type="text" placeholder="Search" className={calendarStyles.searchInput} />
           </div>
         </div>
 
-        {loading ? <div className="py-4 text-lg">Loading events...</div> : null}
+        {loading ? <div className={calendarStyles.loadingText}>Loading events...</div> : null}
 
         <FullCalendar
           ref={calendarRef}

--- a/src/styles/CalendarPage.module.css
+++ b/src/styles/CalendarPage.module.css
@@ -1,0 +1,295 @@
+.page {
+  padding: 32px;
+  font-family: var(--font-lora);
+  max-width: 100%;
+  overflow-x: clip;
+}
+
+.pageTitle {
+  margin: 0 0 14px;
+  font-size: clamp(32px, 2.2vw, 44px);
+  font-weight: 700;
+}
+
+.eventsRow {
+  margin-bottom: 18px;
+}
+
+.responsibilitiesSection {
+  padding: 8px 0 4px;
+}
+
+.responsibilitiesTitle {
+  margin: 0 0 14px;
+  text-align: center;
+  color: #4f6e22;
+  font-size: clamp(24px, 1.7vw, 40px);
+  font-weight: 700;
+}
+
+.responsibilitiesGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(80px, 1fr));
+  gap: 12px;
+}
+
+.responsibilityItem {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.responsibilityIcon {
+  color: #69882f;
+  stroke-width: 1.8;
+}
+
+.responsibilityLabel {
+  color: #4f6e22;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.learnMoreSection {
+  margin: 18px 0 24px;
+  background: #ffffff;
+  border-top: 1px solid #c8c8c8;
+  border-bottom: 1px solid #c8c8c8;
+}
+
+.learnMoreButton {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #4f6e22;
+  font-size: clamp(14px, 1.2vw, 18px);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  cursor: pointer;
+}
+
+.learnMoreIcon {
+  flex-shrink: 0;
+}
+
+.learnMoreContent {
+  border-top: 1px solid #dedede;
+  padding: 18px 20px;
+  font-size: clamp(15px, 1.1vw, 20px);
+  line-height: 1.55;
+  color: #242424;
+  display: grid;
+  gap: 14px;
+  background: #fdfdf9;
+}
+
+.controlsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.controlsLeft {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
+.arrowGroup {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.monthLabel {
+  margin: 0;
+  font-size: clamp(24px, 1.6vw, 32px);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.todayWrap {
+  flex-shrink: 0;
+}
+
+.todayButton {
+  text-transform: none !important;
+  font-weight: 700 !important;
+}
+
+.searchBox {
+  width: 291px;
+  flex-shrink: 0;
+}
+
+.searchInput {
+  width: 100%;
+  height: 50px;
+  border: 1px solid #c2c8d4;
+  border-radius: 999px;
+  background: #ffffff;
+  padding: 0 18px;
+  font-size: 22px;
+  font-weight: 600;
+  color: #111111;
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: #111111;
+}
+
+.loadingText {
+  padding: 16px 0;
+  font-size: 20px;
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 14px 10px 20px;
+    margin: 0 auto;
+  }
+
+  .pageTitle {
+    text-align: center;
+    font-size: 26px;
+    margin-bottom: 12px;
+  }
+
+  .eventsRow {
+    grid-auto-columns: 95px;
+    gap: 8px;
+    padding-bottom: 8px;
+  }
+
+  .eventsRow > div {
+    height: 120px;
+    border-radius: 8px;
+  }
+
+  .eventsRow > div > div:nth-child(3) {
+    top: 4px;
+    padding-right: 4px;
+  }
+
+  .eventsRow > div > div:nth-child(3) > div {
+    font-size: 8px;
+    gap: 4px;
+    padding: 2px 6px;
+    border-width: 1px;
+  }
+
+  .eventsRow > div > div:nth-child(3) > div > span:first-child {
+    font-size: 8px;
+  }
+
+  .eventsRow > div > div:nth-child(4) > div:first-child > div:first-child {
+    font-size: 14px;
+  }
+
+  .eventsRow > div > div:nth-child(4) > div:first-child > div:last-child {
+    margin-top: 3px;
+    font-size: 13px;
+  }
+
+  .eventsRow > div > div:nth-child(4) > div:last-child {
+    left: 6px;
+    right: 6px;
+    bottom: 6px;
+    gap: 4px;
+    font-size: 7px;
+  }
+
+  .eventsRow > div > div:nth-child(4) > div:last-child > span:first-child {
+    font-size: 8px;
+  }
+
+  .eventsRow > div > div:nth-child(4) > div:last-child > span:last-child {
+    max-width: 82px;
+  }
+
+  .eventsRow > div > div:last-child {
+    display: none;
+  }
+
+  .responsibilitiesSection {
+    padding: 10px 0 0;
+  }
+
+  .responsibilitiesTitle {
+    font-size: 26px;
+    margin-bottom: 12px;
+  }
+
+  .responsibilitiesGrid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .responsibilityIcon {
+    width: 34px;
+    height: 34px;
+  }
+
+  .responsibilityLabel {
+    font-size: 11px;
+    line-height: 1.15;
+    word-break: break-word;
+  }
+
+  .learnMoreButton {
+    font-size: 14px;
+    letter-spacing: 0.06em;
+  }
+
+  .learnMoreContent {
+    font-size: 16px;
+    padding: 14px 12px;
+  }
+
+  .controlsRow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    margin-bottom: 8px;
+    gap: 8px;
+  }
+
+  .arrowGroup {
+    display: none;
+  }
+
+  .monthLabel {
+    font-size: 34px;
+  }
+
+  .todayWrap {
+    display: none;
+  }
+
+  .searchBox {
+    width: 108px;
+  }
+
+  .searchInput {
+    height: 32px;
+    padding: 0 10px;
+    font-size: 16px;
+  }
+
+  .loadingText {
+    font-size: 16px;
+    padding: 10px 0;
+  }
+}


### PR DESCRIPTION
## Developer: Lorinc Heutchy

Closes #55 

### Pull Request Summary

Added learn more on home page, with clickable arrow to show or unshow the text
Modified the homepage to look nice on mobile

### Modifications

src/app/calendar/page.tsx
- Added calendar-page-specific UI sections:
- Garden Workday Responsibilities icon row.
- LEARN MORE toggle with expandable explanatory text.
- Switched page layout hooks (title, controls, search, loading text) to use a dedicated calendar CSS module for responsive behavior.

src/styles/CalendarPage.module.css
- New page-scoped stylesheet for calendar-only desktop/mobile styling.
- Includes mobile-specific sizing for Upcoming Events heading/cards and responsive layout for responsibilities, learn-more row, and calendar controls.

### Testing Considerations

Tested on phone resolution with google developer tools, ensure it looks nice on an actual phone

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="552" height="775" alt="image" src="https://github.com/user-attachments/assets/494e8203-f3da-4f42-bbff-750fed095d2c" />
<img width="898" height="631" alt="image" src="https://github.com/user-attachments/assets/b8eccd7a-98bf-4a99-900c-4f82582d91c3" />
<img width="880" height="542" alt="image" src="https://github.com/user-attachments/assets/4353c083-2882-443c-aa94-03605c30888e" />