### PR TITLE
Refine mobile auth layouts

### DIFF
--- a/src/components/AuthMobileHeader.tsx
+++ b/src/components/AuthMobileHeader.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Menu } from "lucide-react";
+
+export default function AuthMobileHeader() {
+  return (
+    <div className="mx-auto flex w-full max-w-[360px] items-center justify-between px-6 py-5 text-black md:hidden">
+      <span className="text-[14px] font-semibold tracking-[0.04em]">GARDEN WORKDAY EVENT</span>
+      <button
+        type="button"
+        aria-label="Open menu"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full text-black"
+      >
+        <Menu size={20} strokeWidth={2.25} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/CreateAccountForm.tsx
+++ b/src/components/CreateAccountForm.tsx
@@ -3,8 +3,10 @@
 import { useMemo, useState } from "react";
 import { useSignUp } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import ConfirmAccountPage from "./ConfirmAccountForm";
+import { CircleAlert } from "lucide-react";
 import { BeatLoader } from "react-spinners";
+import ConfirmAccountPage from "./ConfirmAccountForm";
+import AuthMobileHeader from "./AuthMobileHeader";
 import { StepCircle, StepLine } from "./ui/Stepper";
 
 function isValidEmail(email: string) {
@@ -112,123 +114,159 @@ export default function CreateAccountForm() {
   };
 
   return (
-    <div className="w-full max-w-[820px] pt-14 pb-24">
-      <h1 className="text-center text-4xl font-semibold text-black">Create Account</h1>
+    <div className="w-full max-w-[820px] pb-24 md:pt-14">
+      <AuthMobileHeader />
 
-      <p className="mt-2 text-center text-sm text-gray-700">
-        Already have an Account?{" "}
-        <a href="/login" className="text-black underline">
-          Log in
-        </a>
-      </p>
+      <div className="mx-auto w-full max-w-[360px] px-5 md:max-w-none md:px-0">
+        <h1 className="text-center text-[28px] font-semibold text-black md:text-4xl">Create Account</h1>
+
+        <p className="mt-2 text-center text-[13px] text-gray-700 md:text-sm">
+          Already have an Account?{" "}
+          <a href="/login" className="text-black underline">
+            Log in
+          </a>
+        </p>
+      </div>
 
       <div className="mt-8 flex justify-center">
-        <div className="w-full max-w-[900px]">
-          <div className="flex items-center justify-center gap-6">
+        <div className="w-full max-w-[900px] px-5 md:px-0">
+          <div className="hidden items-center justify-center gap-6 md:flex">
             <StepCircle label="Basic Information" number={1} done={step2Done} active={currentStep === 1} />
-
             <StepLine active={step2Done} />
-
             <StepCircle label="Enter Email" number={2} done={step1Done} active={currentStep === 2} />
-
             <StepLine active={step1Done} />
-
             <StepCircle label="Create Password" number={3} done={step3Done} active={currentStep === 3} />
+          </div>
+
+          <div className="flex items-center justify-center gap-3 md:hidden">
+            <MobileStep number={1} done={step2Done} />
+            <MobileStepLine active={step2Done} />
+            <MobileStep number={2} done={step1Done} />
+            <MobileStepLine active={step1Done} />
+            <MobileStep number={3} done={step3Done} />
           </div>
         </div>
       </div>
 
       {step === "create" ? (
         <div className="mt-10 flex justify-center">
-          <div className="w-full max-w-[520px]">
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              <Field label="Full Name">
-                <PillInput
-                  placeholder="First and last name"
-                  value={fullName}
-                  onChange={(e) => setFullName(e.target.value)}
-                />
-              </Field>
+          <div className="w-full max-w-[520px] px-5 md:px-0">
+            <section>
+              <h2 className="mb-3 flex items-center gap-2 text-[16px] font-semibold text-[#2c2c2c] md:hidden">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#707070] text-[10px]">
+                  1
+                </span>
+                Your Information
+              </h2>
 
-              <Field label="Date of Birth">
-                <PillInput type="date" value={dob} onChange={(e) => setDob(e.target.value)} />
-              </Field>
-            </div>
-
-            <div className="mt-6">
-              <Field label="Email Address">
-                <PillInput
-                  placeholder="example@email.com"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value);
-                    if (emailError) setEmailError("");
-                  }}
-                  onBlur={() => {
-                    const eTrim = email.trim();
-                    if (eTrim.length === 0) setEmailError("Email is required.");
-                    else if (!isValidEmail(eTrim)) setEmailError("Please enter a valid email address.");
-                    else setEmailError("");
-                  }}
-                />
-              </Field>
-
-              {emailError && <p className="mt-2 text-xs text-red-600">{emailError}</p>}
-            </div>
-
-            <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-[1fr_190px]">
-              <div>
-                <Field label="Create Password">
-                  <PasswordInput
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    visible={showPassword}
-                    onToggle={() => setShowPassword((prev) => !prev)}
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+                <Field label="Full Name">
+                  <PillInput
+                    placeholder="First and last name"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
                   />
                 </Field>
 
-                <div className="mt-6">
-                  <Field label="Confirm Password">
+                <Field label="Email Address" className="md:order-3 md:col-span-2">
+                  <PillInput
+                    placeholder="example@email.com"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError("");
+                    }}
+                    onBlur={() => {
+                      const eTrim = email.trim();
+                      if (eTrim.length === 0) setEmailError("Email is required.");
+                      else if (!isValidEmail(eTrim)) setEmailError("Please enter a valid email address.");
+                      else setEmailError("");
+                    }}
+                  />
+                </Field>
+
+                <Field label="Date of Birth" className="mx-auto w-[132px] md:mx-0 md:w-auto md:order-2">
+                  <PillInput
+                    type="date"
+                    value={dob}
+                    onChange={(e) => setDob(e.target.value)}
+                    className="px-3 text-center text-[13px] [color-scheme:light] md:text-left"
+                  />
+                </Field>
+              </div>
+
+              {emailError && <p className="mt-2 text-xs text-red-600">{emailError}</p>}
+            </section>
+
+            <div className="mt-6 rounded-[8px] border-2 border-[#86a9eb] bg-white px-3 py-2 text-[12px] font-semibold text-[#3e3e3e] md:hidden">
+              <div className="flex items-start gap-2">
+                <CircleAlert className="mt-0.5 h-4 w-4 shrink-0 text-[#d96f4a]" strokeWidth={1.75} />
+                <p>Notice: All minors signing up must have a Parent/Guardian information to log in</p>
+              </div>
+            </div>
+
+            <section className="mt-7">
+              <h2 className="mb-3 flex items-center gap-2 text-[16px] font-semibold text-[#2c2c2c] md:hidden">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#707070] text-[10px]">
+                  3
+                </span>
+                Create Password
+              </h2>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_190px] md:gap-6">
+                <div>
+                  <Field label="Create Password">
                     <PasswordInput
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      visible={showConfirmPassword}
-                      onToggle={() => setShowConfirmPassword((prev) => !prev)}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      visible={showPassword}
+                      onToggle={() => setShowPassword((prev) => !prev)}
                     />
                   </Field>
 
-                  {passwordsFilled && password !== confirmPassword && (
-                    <p className="mt-2 text-xs text-red-600">Passwords do not match.</p>
-                  )}
+                  <div className="mt-4 md:mt-6">
+                    <Field label="Confirm Password">
+                      <PasswordInput
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        visible={showConfirmPassword}
+                        onToggle={() => setShowConfirmPassword((prev) => !prev)}
+                      />
+                    </Field>
 
-                  {passwordsFilled &&
-                    password === confirmPassword &&
-                    password.length >= 8 &&
-                    !hasNumberOrSymbol(password) && (
-                      <p className="mt-2 text-xs text-red-600">Password must include at least 1 number or symbol.</p>
+                    {passwordsFilled && password !== confirmPassword && (
+                      <p className="mt-2 text-xs text-red-600">Passwords do not match.</p>
                     )}
-                </div>
-              </div>
 
-              <div className="md:pt-7">
-                <div className="rounded-md border-2 border-[#4e78b7] bg-white p-3 text-sm">
-                  <p className="mb-1 font-semibold text-[#1e2b3a]">Password Requirements:</p>
-                  <ul className="ml-5 list-disc text-[#1e2b3a]">
-                    <li>Minimum 8 Characters</li>
-                    <li>1 number or Symbol</li>
-                  </ul>
+                    {passwordsFilled &&
+                      password === confirmPassword &&
+                      password.length >= 8 &&
+                      !hasNumberOrSymbol(password) && (
+                        <p className="mt-2 text-xs text-red-600">Password must include at least 1 number or symbol.</p>
+                      )}
+                  </div>
+                </div>
+
+                <div className="order-first mx-auto w-[170px] md:order-none md:mx-0 md:w-auto md:pt-7">
+                  <div className="rounded-[8px] border-2 border-[#4e78b7] bg-white p-3 text-center text-[12px] md:text-left md:text-sm">
+                    <p className="mb-1 font-semibold text-[#1e2b3a]">Password Requirements:</p>
+                    <ul className="ml-5 list-disc text-left text-[#1e2b3a]">
+                      <li>Minimum 8 Characters</li>
+                      <li>1 number or Symbol</li>
+                    </ul>
+                  </div>
                 </div>
               </div>
-            </div>
+            </section>
 
             <div className="mt-10 flex justify-center">
               <button
                 type="button"
                 onClick={handleSubmit}
                 disabled={!step3Done}
-                className="rounded-full border border-[#7db456] bg-[#b9e08c] px-10 py-3 font-semibold text-black shadow-[0_2px_0_rgba(0,0,0,0.10)] transition hover:brightness-95 active:brightness-90 disabled:opacity-50"
+                className="h-[38px] rounded-[10px] border-2 border-[#77a94f] bg-[#d5efc1] px-8 text-[14px] font-semibold text-[#4d7a30] shadow-[0_2px_0_rgba(0,0,0,0.10)] transition hover:brightness-95 active:brightness-90 disabled:opacity-50 md:h-auto md:rounded-full md:border md:border-[#7db456] md:bg-[#b9e08c] md:px-10 md:py-3 md:text-base md:text-black"
               >
-                {loading ? <BeatLoader /> : "Confirm Details"}
+                {loading ? <BeatLoader /> : "Create Account"}
               </button>
             </div>
 
@@ -242,10 +280,26 @@ export default function CreateAccountForm() {
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function MobileStep({ number, done }: { number: number; done: boolean }) {
   return (
-    <label className="block">
-      <span className="mb-2 block text-sm font-semibold text-[#1e2b3a]">{label}</span>
+    <div
+      className={`flex h-7 w-7 items-center justify-center rounded-full border-2 text-[13px] font-semibold ${
+        done ? "border-[#4f7cc7] bg-[#4f7cc7] text-white" : "border-[#4f7cc7] text-[#4f7cc7]"
+      }`}
+    >
+      {done ? "✓" : number}
+    </div>
+  );
+}
+
+function MobileStepLine({ active }: { active: boolean }) {
+  return <div className={`h-[2px] w-9 ${active ? "bg-[#4f7cc7]" : "bg-[#d9d9d9]"}`} />;
+}
+
+function Field({ label, children, className = "" }: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <label className={`block ${className}`}>
+      <span className="mb-2 block text-[12px] font-semibold text-[#1e2b3a] md:text-sm">{label}</span>
       {children}
     </label>
   );
@@ -256,7 +310,7 @@ function PillInput({ className = "", ...props }: React.InputHTMLAttributes<HTMLI
     <input
       {...props}
       className={
-        "h-12 w-full rounded-full border border-[#bcd1ea] bg-[#eaf3ff] px-5 text-sm text-[#1e2b3a] placeholder:text-[#6d8197] outline-none focus:border-[#4e78b7] focus:ring-2 focus:ring-[#4e78b7]/30 " +
+        "h-11 w-full rounded-[8px] border-2 border-[#86a9eb] bg-white px-4 text-sm text-[#1e2b3a] placeholder:text-[#9a9a9a] outline-none focus:border-[#4e78b7] focus:ring-2 focus:ring-[#4e78b7]/20 md:h-12 md:rounded-full md:border md:border-[#bcd1ea] md:bg-[#eaf3ff] md:px-5 md:placeholder:text-[#6d8197] md:focus:ring-[#4e78b7]/30 " +
         className
       }
     />
@@ -276,11 +330,11 @@ function PasswordInput({
 }) {
   return (
     <div className="relative">
-      <PillInput type={visible ? "text" : "password"} value={value} onChange={onChange} className="pr-16" />
+      <PillInput type={visible ? "text" : "password"} value={value} onChange={onChange} className="pr-12 md:pr-16" />
       <button
         type="button"
         onClick={onToggle}
-        className="absolute right-4 top-1/2 -translate-y-1/2 text-sm text-[#2b5876]"
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[#2b5876] md:right-4 md:text-sm"
       >
         {visible ? "Hide" : "Show"}
       </button>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -7,6 +7,7 @@ import styles from "../styles/LoginForm.module.css";
 import Image from "next/image";
 import eyeClosed from "../icons/eyeClosed.svg";
 import eyeShow from "../icons/eyeShow.svg";
+import AuthMobileHeader from "./AuthMobileHeader";
 
 function isValidEmail(email: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
@@ -31,6 +32,7 @@ export default function LoginForm() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setSubmitted(true);
     if (!isLoaded) return;
 
     const eTrim = email.trim();
@@ -66,73 +68,90 @@ export default function LoginForm() {
 
   return (
     <div className={styles.loginCard}>
-      <h1 className={styles.title}>Login</h1>
+      <AuthMobileHeader />
 
-      <p className={styles.subtitle}>
-        Don&apos;t have an account?{" "}
-        <a className={styles.loginLink} href="/create-account">
-          Create Account
-        </a>
-      </p>
+      <div className={styles.loginPanel}>
+        <h1 className={styles.title}>Login</h1>
 
-      <form className={styles.loginForm} onSubmit={handleSubmit}>
-        <div className={styles.formGroup}>
-          <label className={styles.formLabel} htmlFor="email">
-            Email Address
-          </label>
+        <p className={styles.subtitle}>
+          Don&apos;t have an Account?{" "}
+          <a className={styles.loginLink} href="/create-account">
+            Create Account
+          </a>
+        </p>
 
-          <input
-            id="email"
-            className={styles.formInput}
-            placeholder="example@email.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            type="email"
-            autoComplete="email"
-            onBlur={() => {
-              const eTrim = email.trim();
-              if (eTrim.length === 0) setEmailError("Email is required.");
-              else if (!isValidEmail(eTrim)) setEmailError("Please enter a valid email address.");
-              else setEmailError("");
-            }}
-            aria-invalid={submitted && !!emailError}
-          />
+        <form className={styles.loginForm} onSubmit={handleSubmit}>
+          <div className={styles.formGroup}>
+            <label className={styles.formLabel} htmlFor="email">
+              Email Address
+            </label>
 
-          {emailError && <p className={styles.fieldError}>{emailError}</p>}
-        </div>
-
-        <div className={styles.formGroup}>
-          <label className={styles.formLabel} htmlFor="password">
-            Password
-          </label>
-
-          <div className={styles.passwordWrapper}>
             <input
-              id="password"
+              id="email"
               className={styles.formInput}
-              placeholder="********"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              type={showPassword ? "text" : "password"}
-              autoComplete="current-password"
+              placeholder="example@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              type="email"
+              autoComplete="email"
+              onBlur={() => {
+                const eTrim = email.trim();
+                if (eTrim.length === 0) setEmailError("Email is required.");
+                else if (!isValidEmail(eTrim)) setEmailError("Please enter a valid email address.");
+                else setEmailError("");
+              }}
+              aria-invalid={submitted && !!emailError}
             />
 
-            <button type="button" className={styles.passwordToggle} onClick={() => setShowPassword((prev) => !prev)}>
-              {showPassword ? (
-                <Image src={eyeClosed} alt="Hide" width={25} height={25} />
-              ) : (
-                <Image src={eyeShow} alt="Show" width={25} height={25} />
-              )}
-            </button>
+            {emailError && <p className={styles.fieldError}>{emailError}</p>}
           </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.formLabel} htmlFor="password">
+              Password
+            </label>
+
+            <div className={styles.passwordWrapper}>
+              <input
+                id="password"
+                className={styles.formInput}
+                placeholder="********************"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                type={showPassword ? "text" : "password"}
+                autoComplete="current-password"
+              />
+
+              <button type="button" className={styles.passwordToggle} onClick={() => setShowPassword((prev) => !prev)}>
+                {showPassword ? (
+                  <Image src={eyeClosed} alt="Hide" width={20} height={20} />
+                ) : (
+                  <Image src={eyeShow} alt="Show" width={20} height={20} />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {error && <p className={styles.error}>{error}</p>}
+
+          <button className={styles.loginButton} type="submit" disabled={!canSubmit}>
+            Log in
+          </button>
+        </form>
+
+        <div className={styles.oauthRow}>
+          <button type="button" className={styles.oauthButton}>
+            Log in w/
+          </button>
+          <button type="button" className={styles.oauthButton}>
+            Log in w/
+          </button>
         </div>
 
-        {error && <p className={styles.error}>{error}</p>}
-
-        <button className={styles.loginButton} type="submit" disabled={!canSubmit}>
-          Next
+        <button type="button" className={styles.forgotLink}>
+          Forgot Password?
         </button>
-      </form>
+      </div>
     </div>
   );
 }

--- a/src/styles/LoginForm.module.css
+++ b/src/styles/LoginForm.module.css
@@ -4,120 +4,237 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   font-family: Lora;
+  background: #fff;
+  padding: 0 0 48px;
+}
+
+.loginPanel {
+  width: min(100%, 360px);
+  padding: 8px 24px 24px;
 }
 
 .title {
   font-weight: 700;
-  font-size: 40px;
+  font-size: 28px;
   line-height: 100%;
   text-align: center;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .subtitle {
   font-weight: 400;
-  font-size: 16px;
-  line-height: 100%;
+  font-size: 13px;
+  line-height: 1.3;
   text-align: center;
-  margin-bottom: 50px;
+  margin-bottom: 36px;
 }
 
 .loginLink {
   text-decoration: underline;
+  color: inherit;
 }
 
 .loginForm {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 18px;
 }
 
 .formGroup {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 7px;
 }
 
 .formLabel {
   font-weight: 400;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 100%;
-  padding-left: 20px;
+  padding-left: 14px;
 }
 
 .formInput {
-  width: 613px;
-  height: 52px;
-  padding: 0 50px 0 20px;
-  border-radius: 30px;
-  border: 1px solid #00000040;
+  width: 100%;
+  height: 44px;
+  padding: 0 46px 0 16px;
+  border-radius: 8px;
+  border: 2px solid #86a9eb;
+  background: #fff;
   font-weight: 500;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 100%;
 }
 
 .formInput::placeholder {
   font-weight: 400;
-  font-size: 16px;
+  font-size: 13px;
   line-height: 100%;
-  color: #999;
+  color: #909090;
 }
 
 .passwordWrapper {
   position: relative;
-  width: 613px;
+  width: 100%;
 }
 
 .passwordToggle {
   position: absolute;
-  right: 16px;
+  right: 12px;
   top: 50%;
   transform: translateY(-50%);
   background: none;
   border: none;
-  font-size: 14px;
   cursor: pointer;
   color: #333;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .loginButton {
-  width: 182px;
-  height: 39px;
+  width: 156px;
+  height: 38px;
   align-self: center;
-  border-radius: 30px;
-  border: 1px solid #a28d8d;
-  background-color: #b2de98;
+  border-radius: 10px;
+  border: 2px solid #77a94f;
+  background-color: #d5efc1;
   font-weight: 700;
-  font-size: 20px;
+  font-size: 14px;
   line-height: 100%;
   cursor: pointer;
-  margin-top: 10px;
+  margin-top: 14px;
+  color: #4d7a30;
+}
+
+.loginButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .oauthRow {
   display: flex;
   justify-content: center;
-  gap: 16px;
-  margin-top: 10px;
+  gap: 18px;
+  margin-top: 28px;
 }
 
 .oauthButton {
-  width: 157px;
-  height: 40px;
-  border-radius: 30px;
+  width: 97px;
+  height: 26px;
+  border-radius: 8px;
   border: 1px solid #00000080;
   background: white;
   font-weight: 400;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 100%;
   cursor: pointer;
 }
 
 .fieldError {
-  margin-top: 6px;
-  font-size: 0.9rem;
+  margin-top: 2px;
+  font-size: 12px;
   color: #c0392b;
+  padding-left: 14px;
+}
+
+.error {
+  margin-top: 2px;
+  font-size: 12px;
+  color: #c0392b;
+  text-align: center;
+}
+
+.forgotLink {
+  display: block;
+  margin-top: 18px;
+  text-align: center;
+  font-size: 13px;
+  color: inherit;
+  text-decoration: underline;
+  background: none;
+  border: none;
+  width: 100%;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .loginCard {
+    justify-content: center;
+    padding: 32px 24px 64px;
+  }
+
+  .loginPanel {
+    width: min(100%, 640px);
+    padding: 0;
+  }
+
+  .title {
+    font-size: 40px;
+    margin-bottom: 12px;
+  }
+
+  .subtitle {
+    font-size: 16px;
+    margin-bottom: 50px;
+  }
+
+  .formLabel {
+    font-size: 14px;
+    padding-left: 20px;
+  }
+
+  .formInput {
+    height: 52px;
+    padding: 0 50px 0 20px;
+    border-radius: 30px;
+    border: 1px solid #00000040;
+    font-size: 16px;
+  }
+
+  .formInput::placeholder {
+    font-size: 16px;
+  }
+
+  .passwordToggle {
+    right: 16px;
+  }
+
+  .loginButton {
+    width: 182px;
+    height: 39px;
+    border-radius: 30px;
+    border: 1px solid #a28d8d;
+    background-color: #b2de98;
+    font-size: 20px;
+    color: #000;
+  }
+
+  .oauthRow {
+    gap: 16px;
+    margin-top: 18px;
+  }
+
+  .oauthButton {
+    width: 157px;
+    height: 40px;
+    border-radius: 30px;
+    font-size: 14px;
+  }
+
+  .fieldError {
+    font-size: 0.9rem;
+    padding-left: 20px;
+  }
+
+  .error {
+    font-size: 0.9rem;
+  }
+
+  .forgotLink {
+    margin-top: 20px;
+    font-size: 15px;
+  }
 }


### PR DESCRIPTION
## Developer: Vinayak 

Closes #54 

### Pull Request Summary

Mobile frontend for create account page and login pages

### Modifications

src/components/AuthMobileHeader.tsx
- added AuthMobileHeader() component

src/components/CreateAccountForm.tsx
- changed styling for page depending on screen
- changed use of stepper componenets

src/styles/LoginForm.module.css
- Styling changed to match figma



### Testing Considerations

Tested view of create account and login pages on all mobile screens, and desktop to ensure consistency with figma. 
Tested interaction functionality to make sure the reorganization didn't cause bugs.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast


<img width="381" height="823" alt="Screenshot 2026-04-22 at 5 24 04 PM" src="https://github.com/user-attachments/assets/c32ece1f-327e-4c87-8962-b3ae1e55d45a" />

<img width="380" height="821" alt="Screenshot 2026-04-22 at 5 24 26 PM" src="https://github.com/user-attachments/assets/5ffd0e23-1e54-4fa0-96b7-0a94669c2e92" />

<img width="377" height="579" alt="Screenshot 2026-04-22 at 5 24 39 PM" src="https://github.com/user-attachments/assets/622c2979-38c2-463c-9bdc-91bbe6db4966" />
