### PR TITLE
Upcoming events bug FIX

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -100,7 +100,10 @@ export default function CalendarPage() {
 
     setSearchResults(results);
   };
-  const upcomingCardEvents = MOCK_EVENTS.filter((event) => event.section === "upcoming");
+  const upcomingCardEvents = MOCK_EVENTS.filter((event) => {
+    const now = new Date();
+    return now < event.date;
+  });
   const responsibilities = [
     { label: "Planting", Icon: Leaf },
     { label: "Building Plant Beds", Icon: House },
@@ -114,12 +117,15 @@ export default function CalendarPage() {
       <NavBarWrapper />
       <div className={calendarStyles.page}>
         <h1 className={calendarStyles.pageTitle}>Upcoming Events</h1>
-
-        <div className={`${styles.row} ${calendarStyles.eventsRow}`}>
-          {upcomingCardEvents.map((event) => (
-            <VolunteerEventCard key={event.id} event={event} />
-          ))}
-        </div>
+        {upcomingCardEvents.length != 0 ? (
+          <div className={`${styles.row} ${calendarStyles.eventsRow}`}>
+            {upcomingCardEvents.map((event) => (
+              <VolunteerEventCard key={event.id} event={event} />
+            ))}
+          </div>
+        ) : (
+          <div className="m-3 mx-10 text-3xl">Nothing for now... check back soon!</div>
+        )}
 
         <section className={calendarStyles.responsibilitiesSection}>
           <h2 className={calendarStyles.responsibilitiesTitle}>Garden Workday Responsibilities</h2>

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -291,6 +291,32 @@ export const MOCK_EVENTS: AppEvent[] = [
     attendanceCount: 13,
     volunteerStatus: "attended",
   },
+  {
+    id: "p12",
+    title: "Rain Garden Maintenance",
+    date: new Date(2026, 6, 18),
+    startTime: "8:30 am",
+    endTime: "11:30 am",
+    school: "Judkins Middle School",
+    imageUrl: "/images/testImage5.jpg",
+    section: "upcoming",
+    registeredCount: 17,
+    attendanceCount: 13,
+    volunteerStatus: "none",
+  },
+  {
+    id: "p13",
+    title: "Garden Tool Repair Night",
+    date: new Date(2026, 5, 13),
+    startTime: "9:30 am",
+    endTime: "11:30 am",
+    school: "San Luis Obispo High School",
+    imageUrl: "/images/testImage5.jpg",
+    section: "upcoming",
+    registeredCount: 17,
+    attendanceCount: 13,
+    volunteerStatus: "none",
+  },
 ];
 
 export const CALENDAR_CARD_EVENTS = MOCK_EVENTS.filter((event) => event.section === "upcoming").map((event) => ({


### PR DESCRIPTION
## Developer: Travis

Closes #72 

### Pull Request Summary

Prevent events that have past from showing up on Upcoming Events carousel

### Modifications

Added a filter to the upcomingCardEvents array that filters out events that have past. Added a ternary operator to check if the upcoming events array is empty, adding placeholder text if it is.

I was unable to replicate the issue of Upcoming Events bleeding into the cards. 

### Testing Considerations

n/a

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast

Filtered events:
<img width="586" height="364" alt="image" src="https://github.com/user-attachments/assets/88760124-7e94-49cf-98da-dc3262d578e5" />

Me trying to replicate the first bug:

https://github.com/user-attachments/assets/a584ff57-93c8-4b42-98ff-bae8d011aecf

