### PR TITLE
Added routes for registration

### DIFF
--- a/src/app/api/events/registration/[registrationId]/route.ts
+++ b/src/app/api/events/registration/[registrationId]/route.ts
@@ -1,0 +1,67 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Registration from "@/database/models/Registration";
+
+// Return a specific registration
+export async function GET(request: Request, { params }: { params: { registrationId: string } }) {
+  try {
+    await connectDB();
+    const registration = await Registration.findById(params.registrationId);
+
+    if (!registration) {
+      return NextResponse.json({ error: "Registration not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ registration });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to fetch registration" }, { status: 500 });
+  }
+}
+
+// Patch a specific registration
+export async function PATCH(request: Request, { params }: { params: { registrationId: string } }) {
+  try {
+    await connectDB();
+    const body = await request.json();
+
+    const updated = await Registration.findByIdAndUpdate(
+      params.registrationId,
+      {
+        $set: {
+          partyMembers: body.partyMembers,
+          affiliatedOrganization: body.affiliatedOrganization,
+          additionalComments: body.additionalComments,
+        },
+      },
+      { new: true },
+    );
+
+    if (!updated) {
+      return NextResponse.json({ error: "Registration not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: "Registration edited successfully", registration: updated }, { status: 200 });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to update registration" }, { status: 500 });
+  }
+}
+
+// Delete a specific registration
+export async function DELETE(request: Request, { params }: { params: { registrationId: string } }) {
+  try {
+    await connectDB();
+
+    const deleted = await Registration.findByIdAndDelete(params.registrationId);
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Registration not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: "Registration deleted successfully" }, { status: 200 });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to delete registration" }, { status: 500 });
+  }
+}

--- a/src/app/api/events/registration/event/[eventId]/route.ts
+++ b/src/app/api/events/registration/event/[eventId]/route.ts
@@ -1,0 +1,21 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Registration from "@/database/models/Registration";
+const mongoose = require("mongoose");
+
+//Return all registrations that match an eventId
+export async function GET(request: Request, { params }: { params: { eventId: string } }) {
+  try {
+    await connectDB();
+    const registrations = await Registration.find({ eventId: params.eventId });
+
+    if (!registrations) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ registrations });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to fetch events" }, { status: 500 });
+  }
+}

--- a/src/app/api/events/registration/route.ts
+++ b/src/app/api/events/registration/route.ts
@@ -1,0 +1,38 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Registration from "@/database/models/Registration";
+
+//Return all registrations from all events
+export async function GET() {
+  try {
+    await connectDB();
+    const registrations = await Registration.find({});
+
+    return NextResponse.json({ registrations });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to fetch events" }, { status: 500 });
+  }
+}
+
+//add a registration
+export async function POST(request: Request) {
+  try {
+    await connectDB();
+    const registration = await request.json();
+
+    const newRegistration = new Registration({
+      eventId: registration.eventId,
+      partyMembers: registration.partyMembers,
+      affiliatedOrganization: registration.affiliatedOrganization,
+      additionalComments: registration.additionalComments,
+    });
+
+    await newRegistration.save();
+
+    return NextResponse.json({ message: "Registration created successfully" }, { status: 201 });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to create event" }, { status: 500 });
+  }
+}

--- a/src/app/api/events/registration/users/[userEmail]/route.ts
+++ b/src/app/api/events/registration/users/[userEmail]/route.ts
@@ -1,0 +1,22 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Registration from "@/database/models/Registration";
+
+// Return all registrations of a user
+export async function GET(request: Request, { params }: { params: { userEmail: string } }) {
+  try {
+    await connectDB();
+    const registrations = await Registration.find({
+      "partyMembers.email": params.userEmail,
+    }).populate("eventId");
+
+    if (!registrations) {
+      return NextResponse.json({ error: "Registration not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ registrations });
+  } catch (error) {
+    console.error("Database Error:", error);
+    return NextResponse.json({ error: "Failed to fetch registration" }, { status: 500 });
+  }
+}

--- a/src/app/events/[eventId]/register/page.tsx
+++ b/src/app/events/[eventId]/register/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import Navbar from "@/components/Navbar";
 import { StepCircle, StepLine } from "@/components/ui/Stepper";
+import { useParams } from "next/navigation";
 
 type RegistrationMode = "loggedIn" | "guest";
 type RegistrationStep = 1 | 2 | 3;
@@ -52,6 +53,9 @@ export default function EventRegistrationPage() {
   const [partyMembersError, setPartyMembersError] = useState("");
   const [didHydrateMode, setDidHydrateMode] = useState(false);
   const [showRegisteredMessage, setShowRegisteredMessage] = useState(false);
+
+  const params = useParams();
+  const id = params.eventId as string;
 
   useEffect(() => {
     if (!isLoaded || didHydrateMode) return;
@@ -178,6 +182,46 @@ export default function EventRegistrationPage() {
     setShowRegisteredMessage(false);
   };
 
+  const handleRegistration = async () => {
+    let tempPartyMembers = partyMembers
+      .filter((pm) => pm.name && pm.email)
+      .map((pm) => {
+        return {
+          name: pm.name,
+          email: pm.email,
+          waiverSigned: false,
+          registrant: false,
+          attending: true,
+          attended: false,
+        };
+      });
+
+    const registrant = {
+      name: mode == "loggedIn" ? primaryName : guestName,
+      email: mode == "loggedIn" ? primaryEmail : guestEmail,
+      waiverSigned: false,
+      registrant: true,
+      attending: true,
+      attended: false,
+    };
+
+    tempPartyMembers = [registrant, ...tempPartyMembers];
+
+    const registrationBody = {
+      eventId: id,
+      partyMembers: tempPartyMembers,
+      affiliatedOrganization: organization,
+      additionalComments: notes,
+    };
+
+    const response = await fetch(`/api/events/registration`, {
+      method: "POST",
+      body: JSON.stringify(registrationBody),
+    });
+
+    console.log(response);
+  };
+
   return (
     <div className="min-h-screen bg-[#f7f7f2] font-lora text-[#161616]">
       <Navbar mode={navbarMode} />
@@ -249,7 +293,7 @@ export default function EventRegistrationPage() {
                 setShowRegisteredMessage(false);
                 setStep(2);
               }}
-              onRegister={() => setShowRegisteredMessage(true)}
+              onRegister={() => handleRegistration()}
             />
           ) : null}
         </section>

--- a/src/database/models/Registration.ts
+++ b/src/database/models/Registration.ts
@@ -1,0 +1,74 @@
+import mongoose, { Schema, Types } from "mongoose";
+import "@/database/models/Event";
+
+const partyMemberSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    waiverSigned: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    registrant: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    attending: {
+      type: Boolean,
+      required: true,
+      default: true,
+    },
+    attended: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+  },
+  { _id: false },
+);
+
+const registrationSchema = new Schema(
+  {
+    eventId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: "Event",
+      index: true,
+    },
+    partyMembers: {
+      type: [partyMemberSchema],
+      required: true,
+      validate: {
+        validator: (arr: unknown[]) => Array.isArray(arr) && arr.length > 0,
+        message: "At least one party member is required",
+      },
+    },
+    affiliatedOrganization: {
+      type: String,
+      required: false,
+      ref: "Organization",
+    },
+    additionalComments: {
+      type: String,
+      required: false,
+      trim: true,
+    },
+  },
+  {
+    collection: "registrations",
+    timestamps: true,
+  },
+);
+
+export default mongoose.models.Registration || mongoose.model("Registration", registrationSchema);


### PR DESCRIPTION
## Developer: Ella Hagen

Closes #76

### Pull Request Summary

Added routes for event registration

### Modifications
Created
/database/models/Registration.ts

/api/events/registration/route.ts
GET - return all registrations for all events
POST - adds a new registration

/api/events/registration/[registrationId]/route.ts
GET - get a specific registration
PATCH - edit a specific registration
DELETE -  delete a specific registration

/api/events/registration/event/[eventId]/route.ts
GET - get all registrations associated with an event

/api/events/registration/users/[userEmail]/route.ts
GET - returns all registrations of a user based on their email (instead of id, just in case it's needed for a non registered user), joined with event data.

Edited
/events/[eventId]/register - added call to POST for testing.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
GET - return all registrations for all events
<img width="887" height="699" alt="Screenshot 2026-04-29 at 4 54 17 PM" src="https://github.com/user-attachments/assets/9859436e-311f-4085-a16c-06b8fd6cb7b1" />
POST - adds a new registration
<img width="846" height="668" alt="Screenshot 2026-04-29 at 4 55 59 PM" src="https://github.com/user-attachments/assets/c4930495-4612-4932-a4a4-c13645bca57b" />
PATCH - edit a specific registration
<img width="875" height="680" alt="Screenshot 2026-04-29 at 4 57 08 PM" src="https://github.com/user-attachments/assets/6545983a-f7d2-4e54-bf73-7505c1feeeeb" />
DELETE -  delete a specific registration
<img width="872" height="646" alt="Screenshot 2026-04-29 at 4 57 39 PM" src="https://github.com/user-attachments/assets/8fe795b1-bb1f-4bd5-aa2d-4276070b1c4e" />
GET - get all registrations associated with an event
<img width="883" height="712" alt="Screenshot 2026-04-29 at 4 58 29 PM" src="https://github.com/user-attachments/assets/56ca1aca-e0aa-4374-8068-9f9d7b99406a" />
GET - returns all registrations of a user based on their email (instead of id, just in case it's needed for a non registered user), joined with event data.
<img width="882" height="683" alt="Screenshot 2026-04-29 at 4 59 51 PM" src="https://github.com/user-attachments/assets/29f7fc86-ebcb-4b6f-bbc5-e364dcbc8b07" />

