### PR TITLE
Gate routes based on user role using Clerk middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,35 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
+const isAdminRoute = createRouteMatcher([
+  "/admin-account(.*)",
+  "/admin-calendar(.*)",
+  "/admin-event-details(.*)",
+  "/admin-events(.*)",
+  "/report(.*)",
+]);
+
+const isLoggedInRoute = createRouteMatcher([
+  "/account(.*)",
+  "/calendar(.*)",
+  "/checkin(.*)",
+  "/edit-registration(.*)",
+  "/events(.*)",
+]);
 
 export default clerkMiddleware(async (auth, req) => {
   const session = await auth();
+  const userId = session.userId;
+
   const role = (session.sessionClaims?.publicMetadata as { role?: string })?.role;
+
+  if (!userId && isLoggedInRoute(req)) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
 
   if (isAdminRoute(req) && role !== "admin") {
     return NextResponse.redirect(new URL("/", req.url));
   }
+
+  return NextResponse.next();
 });


### PR DESCRIPTION
## Developer: Amogh Arora

Closes #95 

### Pull Request Summary

Gates pages based on user authentication status and role using Clerk middleware.

### Modifications

- `src/middleware.ts`
  - Added logged-in-only route protection for volunteer pages such as `/events`, `/account`, `/calendar`, `/checkin`, and `/edit-registration`
  - Added admin-only route protection for `/report` and admin routes
  - Redirects logged-out users to `/login`
  - Redirects non-admin users away from admin-only pages

### Testing Considerations

- Verified logged-out users are redirected when accessing protected pages
- Verified app runs without middleware errors
- Admin/volunteer role behavior should be verified once Clerk role metadata/test accounts are available

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

N/A — middleware-only route gating change.