### PR TITLE
Integrate Jotform API for Waiver Status

### DIFF
--- a/src/app/api/me/waiver-status/route.ts
+++ b/src/app/api/me/waiver-status/route.ts
@@ -1,0 +1,121 @@
+import connectDB from "@/database/db";
+import User from "@/database/models/User";
+import Waiver from "@/database/models/Waiver";
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+type WaiverStatusValue = "complete" | "incomplete";
+
+const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const JOTFORM_SUBMISSIONS_LIMIT = 1000;
+
+const apiKey = process.env.JOTFORM_API_KEY;
+const baseUrl = process.env.JOTFORM_BASE_URL;
+const formId = process.env.JOTFORM_WAIVER_FORM_ID;
+
+export async function GET() {
+  /*Check ENV vars*/
+  if (!apiKey || !baseUrl || !formId) {
+    return NextResponse.json({ error: "ENV variables invalid" }, { status: 500 });
+  }
+
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await connectDB();
+
+  const user = await User.findOne({
+    clerkId: userId,
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "No user found in database" }, { status: 404 });
+  }
+
+  const email = user.email;
+
+  if (!email) {
+    return NextResponse.json({ error: "No email found for user" }, { status: 404 });
+  }
+
+  const normalizedEmail = normalizeEmail(email);
+
+  const existingWaiver = await Waiver.findOne({
+    clerkId: userId,
+  });
+
+  if (existingWaiver) {
+    const age = Date.now() - existingWaiver.waiverLastCheckedAt.getTime();
+    if (age < CACHE_MAX_AGE_MS || existingWaiver.status === "complete") {
+      return NextResponse.json({
+        status: existingWaiver.status,
+        source: "cache",
+        checkedAt: existingWaiver.waiverLastCheckedAt,
+      });
+    }
+  }
+
+  const submissionUrl = new URL(`/form/${formId}/submissions`, baseUrl);
+  submissionUrl.searchParams.set("limit", String(JOTFORM_SUBMISSIONS_LIMIT));
+
+  const response = await fetch(submissionUrl.toString(), { headers: { APIKEY: apiKey } });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: "API call failed" }, { status: 500 });
+  }
+
+  const data = await response.json();
+  const submissions = data.content;
+
+  if (!Array.isArray(submissions)) {
+    return NextResponse.json({ error: "Invalid Jotform Response" }, { status: 500 });
+  }
+
+  const matchingSubmission = submissions.find((submission) => {
+    return getSubmissionEmail(submission.answers) === normalizedEmail;
+  });
+
+  let status: WaiverStatusValue;
+  if (matchingSubmission) {
+    status = "complete";
+  } else {
+    status = "incomplete";
+  }
+
+  const time = new Date();
+
+  await Waiver.findOneAndUpdate(
+    { clerkId: userId },
+    {
+      clerkId: userId,
+      email: normalizedEmail,
+      status: status,
+      waiverLastCheckedAt: time,
+      waiverSubmissionId: matchingSubmission?.id ?? null,
+    },
+    { upsert: true, new: true },
+  );
+
+  return NextResponse.json({ status, source: "jotform", checkedAt: time });
+}
+
+function normalizeEmail(email: string) {
+  return email.toLowerCase().trim();
+}
+
+function getSubmissionEmail(answers: any) {
+  if (!answers || typeof answers !== "object") {
+    return null;
+  }
+
+  const vals: any[] = Object.values(answers);
+  for (const item of vals) {
+    if (item && typeof item === "object" && item.type === "control_email" && typeof item.answer === "string") {
+      return normalizeEmail(item.answer);
+    }
+  }
+  return null;
+}

--- a/src/app/api/me/waiver-status/route.ts
+++ b/src/app/api/me/waiver-status/route.ts
@@ -4,18 +4,18 @@ import Waiver from "@/database/models/Waiver";
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-type WaiverStatusValue = "complete" | "incomplete";
-
-const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+//const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CACHE_MAX_AGE_MS = 1000 * 2;
 const JOTFORM_SUBMISSIONS_LIMIT = 1000;
 
 const apiKey = process.env.JOTFORM_API_KEY;
 const baseUrl = process.env.JOTFORM_BASE_URL;
 const formId = process.env.JOTFORM_WAIVER_FORM_ID;
+const schoolFieldName = process.env.JOTFORM_SCHOOL_FIELD_NAME;
 
 export async function GET() {
   /*Check ENV vars*/
-  if (!apiKey || !baseUrl || !formId) {
+  if (!apiKey || !baseUrl || !formId || !schoolFieldName) {
     return NextResponse.json({ error: "ENV variables invalid" }, { status: 500 });
   }
 
@@ -43,17 +43,24 @@ export async function GET() {
 
   const normalizedEmail = normalizeEmail(email);
 
-  const existingWaiver = await Waiver.findOne({
+  const existingWaivers = await Waiver.find({
     clerkId: userId,
   });
 
-  if (existingWaiver) {
-    const age = Date.now() - existingWaiver.waiverLastCheckedAt.getTime();
-    if (age < CACHE_MAX_AGE_MS || existingWaiver.status === "complete") {
+  if (existingWaivers.length > 0) {
+    const allWaiversFresh = existingWaivers.every((waiver) => {
+      const age = Date.now() - waiver.waiverLastCheckedAt.getTime();
+      return age < CACHE_MAX_AGE_MS;
+    });
+
+    if (allWaiversFresh) {
+      const completedSchools = existingWaivers.map((waiver) => {
+        return waiver.schoolNormalized;
+      });
       return NextResponse.json({
-        status: existingWaiver.status,
+        completedSchools,
         source: "cache",
-        checkedAt: existingWaiver.waiverLastCheckedAt,
+        checkedAt: existingWaivers[0].waiverLastCheckedAt,
       });
     }
   }
@@ -74,36 +81,50 @@ export async function GET() {
     return NextResponse.json({ error: "Invalid Jotform Response" }, { status: 500 });
   }
 
-  const matchingSubmission = submissions.find((submission) => {
+  const matchingSubmissions = submissions.filter((submission) => {
     return getSubmissionEmail(submission.answers) === normalizedEmail;
   });
 
-  let status: WaiverStatusValue;
-  if (matchingSubmission) {
-    status = "complete";
-  } else {
-    status = "incomplete";
-  }
+  const completedSchools = Array.from(
+    new Set(
+      matchingSubmissions
+        .map((submission) => {
+          return getSubmissionSchool(submission.answers);
+        })
+        .filter((school) => {
+          return school !== null;
+        }),
+    ),
+  );
 
   const time = new Date();
 
-  await Waiver.findOneAndUpdate(
-    { clerkId: userId },
-    {
-      clerkId: userId,
-      email: normalizedEmail,
-      status: status,
-      waiverLastCheckedAt: time,
-      waiverSubmissionId: matchingSubmission?.id ?? null,
-    },
-    { upsert: true, new: true },
-  );
+  for (const school of completedSchools) {
+    await Waiver.findOneAndUpdate(
+      {
+        clerkId: userId,
+        schoolNormalized: school,
+      },
+      {
+        clerkId: userId,
+        schoolNormalized: school,
+        email: normalizedEmail,
+        status: "complete",
+        waiverLastCheckedAt: time,
+      },
+      { upsert: true, new: true },
+    );
+  }
 
-  return NextResponse.json({ status, source: "jotform", checkedAt: time });
+  return NextResponse.json({ completedSchools, source: "jotform", checkedAt: time });
 }
 
 function normalizeEmail(email: string) {
   return email.toLowerCase().trim();
+}
+
+function normalizeSchool(school: string) {
+  return school.toLowerCase().trim().replace(/\s+/g, " ");
 }
 
 function getSubmissionEmail(answers: any) {
@@ -115,6 +136,21 @@ function getSubmissionEmail(answers: any) {
   for (const item of vals) {
     if (item && typeof item === "object" && item.type === "control_email" && typeof item.answer === "string") {
       return normalizeEmail(item.answer);
+    }
+  }
+  return null;
+}
+
+function getSubmissionSchool(answers: any) {
+  if (!answers || typeof answers !== "object") {
+    return null;
+  }
+
+  const vals: any[] = Object.values(answers);
+
+  for (const item of vals) {
+    if (item && typeof item === "object" && item.name === schoolFieldName && typeof item.answer === "string") {
+      return normalizeSchool(item.answer);
     }
   }
   return null;

--- a/src/app/api/me/waiver-status/route.ts
+++ b/src/app/api/me/waiver-status/route.ts
@@ -5,7 +5,7 @@ import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 //const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-const CACHE_MAX_AGE_MS = 1000 * 2;
+const CACHE_MAX_AGE_MS = 1000 * 200000;
 const JOTFORM_SUBMISSIONS_LIMIT = 1000;
 
 const apiKey = process.env.JOTFORM_API_KEY;
@@ -124,7 +124,7 @@ function normalizeEmail(email: string) {
 }
 
 function normalizeSchool(school: string) {
-  return school.toLowerCase().trim().replace(/\s+/g, " ");
+  return school.toLowerCase().trim().replace(/\./g, "");
 }
 
 function getSubmissionEmail(answers: any) {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -43,7 +43,7 @@ export default function CalendarPage() {
   const { isLoaded, user } = useUser();
   const isAdmin = role === "admin";
   const userEmail = user?.primaryEmailAddress?.emailAddress?.toLowerCase();
-  const { status: waiverStatus } = useWaiverStatus(role === "volunteer");
+  const { completedSchools } = useWaiverStatus(role === "volunteer");
   const calendarRef = useRef<FullCalendar>(null);
   const [viewDate, setViewDate] = useState(new Date());
   const [searchInput, setSearchInput] = useState("");
@@ -198,13 +198,12 @@ export default function CalendarPage() {
   const upcomingCardEvents = useMemo(() => {
     const baseUpcomingEvents = events.filter((event) => isUpcomingEvent(event));
 
-    if (isAdmin || !waiverStatus) {
+    if (isAdmin || completedSchools === null) {
       return baseUpcomingEvents;
     }
 
-    return baseUpcomingEvents.map((event) => applyWaiverStatusToEvent(event, waiverStatus));
-  }, [events, isAdmin, waiverStatus]);
-
+    return baseUpcomingEvents.map((event) => applyWaiverStatusToEvent(event, completedSchools));
+  }, [events, isAdmin, completedSchools]);
   const responsibilities = [
     { label: "Planting", Icon: Leaf },
     { label: "Building Plant Beds", Icon: House },

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import {
   BookOpen,
@@ -26,6 +26,7 @@ import { AppEvent, isUpcomingEvent } from "@/data/events";
 import { useRole } from "@/hooks/useRole";
 import CreateEventModal from "@/components/CreateEventModal";
 import EventPopup from "@/components/EventPopup";
+import { applyWaiverStatusToEvent, useWaiverStatus } from "@/hooks/useWaiverStatus";
 
 type RegistrationEvent = {
   _id?: string;
@@ -42,6 +43,7 @@ export default function CalendarPage() {
   const { isLoaded, user } = useUser();
   const isAdmin = role === "admin";
   const userEmail = user?.primaryEmailAddress?.emailAddress?.toLowerCase();
+  const { status: waiverStatus } = useWaiverStatus(role === "volunteer");
   const calendarRef = useRef<FullCalendar>(null);
   const [viewDate, setViewDate] = useState(new Date());
   const [searchInput, setSearchInput] = useState("");
@@ -193,7 +195,15 @@ export default function CalendarPage() {
     }
   };
 
-  const upcomingCardEvents = events.filter((event) => isUpcomingEvent(event));
+  const upcomingCardEvents = useMemo(() => {
+    const baseUpcomingEvents = events.filter((event) => isUpcomingEvent(event));
+
+    if (isAdmin || !waiverStatus) {
+      return baseUpcomingEvents;
+    }
+
+    return baseUpcomingEvents.map((event) => applyWaiverStatusToEvent(event, waiverStatus));
+  }, [events, isAdmin, waiverStatus]);
 
   const responsibilities = [
     { label: "Planting", Icon: Leaf },

--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useUser } from "@clerk/nextjs";
 import { LoaderCircle } from "lucide-react";
 import { useRole } from "@/hooks/useRole";
+import { applyWaiverStatusToEvent, useWaiverStatus } from "@/hooks/useWaiverStatus";
 import styles from "@/styles/VolunteerEventsPage.module.css";
 import VolunteerEventCard from "@/components/VolunteerEventCard";
 import AdminEventCard from "@/components/AdminEventCard";
@@ -108,6 +109,7 @@ export default function VolunteerEventsPage() {
   const { isLoaded, user } = useUser();
   const isAdminView = role === "admin";
   const userEmail = user?.primaryEmailAddress?.emailAddress?.toLowerCase();
+  const { status: waiverStatus } = useWaiverStatus(isLoaded && !isAdminView);
   const [events, setEvents] = useState<AppEvent[]>([]);
   const [registrationIdsByEventId, setRegistrationIdsByEventId] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
@@ -184,6 +186,14 @@ export default function VolunteerEventsPage() {
     fetchEvents();
   }, [isAdminView, isLoaded, userEmail]);
 
+  const eventsWithWaiverStatus = useMemo(() => {
+    if (isAdminView || !waiverStatus) {
+      return events;
+    }
+
+    return events.map((event) => applyWaiverStatusToEvent(event, waiverStatus));
+  }, [events, isAdminView, waiverStatus]);
+
   if (!isLoaded || loading) {
     return (
       <main className={styles.pageLoading} aria-live="polite">
@@ -193,8 +203,8 @@ export default function VolunteerEventsPage() {
     );
   }
 
-  const upcoming = events.filter((e) => isUpcomingEvent(e) && isInDateRange(e.startTime, upStart, upEnd));
-  const past = events.filter((e) => isPastEvent(e) && isInDateRange(e.startTime, pastStart, pastEnd));
+  const upcoming = eventsWithWaiverStatus.filter((e) => isUpcomingEvent(e) && isInDateRange(e.startTime, upStart, upEnd));
+  const past = eventsWithWaiverStatus.filter((e) => isPastEvent(e) && isInDateRange(e.startTime, pastStart, pastEnd));
 
   const upcomingSorted = [...upcoming].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
   const pastSorted = [...past].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());

--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -109,7 +109,7 @@ export default function VolunteerEventsPage() {
   const { isLoaded, user } = useUser();
   const isAdminView = role === "admin";
   const userEmail = user?.primaryEmailAddress?.emailAddress?.toLowerCase();
-  const { status: waiverStatus } = useWaiverStatus(isLoaded && !isAdminView);
+  const { completedSchools } = useWaiverStatus(isLoaded && !isAdminView);
   const [events, setEvents] = useState<AppEvent[]>([]);
   const [registrationIdsByEventId, setRegistrationIdsByEventId] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
@@ -187,12 +187,12 @@ export default function VolunteerEventsPage() {
   }, [isAdminView, isLoaded, userEmail]);
 
   const eventsWithWaiverStatus = useMemo(() => {
-    if (isAdminView || !waiverStatus) {
+    if (isAdminView || completedSchools === null) {
       return events;
     }
 
-    return events.map((event) => applyWaiverStatusToEvent(event, waiverStatus));
-  }, [events, isAdminView, waiverStatus]);
+    return events.map((event) => applyWaiverStatusToEvent(event, completedSchools));
+  }, [events, isAdminView, completedSchools]);
 
   if (!isLoaded || loading) {
     return (

--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -203,7 +203,9 @@ export default function VolunteerEventsPage() {
     );
   }
 
-  const upcoming = eventsWithWaiverStatus.filter((e) => isUpcomingEvent(e) && isInDateRange(e.startTime, upStart, upEnd));
+  const upcoming = eventsWithWaiverStatus.filter(
+    (e) => isUpcomingEvent(e) && isInDateRange(e.startTime, upStart, upEnd),
+  );
   const past = eventsWithWaiverStatus.filter((e) => isPastEvent(e) && isInDateRange(e.startTime, pastStart, pastEnd));
 
   const upcomingSorted = [...upcoming].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -8,6 +8,7 @@ export type AppEvent = {
   imageUrl?: string;
   registeredCount: number;
   attendanceCount?: number;
+  waiverSigned?: boolean;
 };
 
 function startOfDay(date: Date) {

--- a/src/database/models/Waiver.ts
+++ b/src/database/models/Waiver.ts
@@ -2,8 +2,10 @@ import mongoose from "mongoose";
 
 const waiverSchema = new mongoose.Schema(
   {
-    clerkId: { type: String, required: true, unique: true },
+    clerkId: { type: String, required: true },
     email: { type: String, required: true },
+    school: { type: String },
+    schoolNormalized: { type: String, required: true },
     status: { type: String, enum: ["complete", "incomplete"], required: true, default: "incomplete" },
     waiverSubmissionId: { type: String, required: false },
     waiverSignedAt: { type: Date, required: false },
@@ -14,5 +16,7 @@ const waiverSchema = new mongoose.Schema(
     timestamps: true,
   },
 );
+
+waiverSchema.index({ clerkId: 1, schoolNormalized: 1 }, { unique: true });
 
 export default mongoose.models.Waiver || mongoose.model("Waiver", waiverSchema);

--- a/src/database/models/Waiver.ts
+++ b/src/database/models/Waiver.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+
+const waiverSchema = new mongoose.Schema(
+  {
+    clerkId: { type: String, required: true, unique: true },
+    email: { type: String, required: true },
+    status: { type: String, enum: ["complete", "incomplete"], required: true, default: "incomplete" },
+    waiverSubmissionId: { type: String, required: false },
+    waiverSignedAt: { type: Date, required: false },
+    waiverLastCheckedAt: { type: Date, required: true, default: Date.now },
+  },
+  {
+    collection: "waivers",
+    timestamps: true,
+  },
+);
+
+export default mongoose.models.Waiver || mongoose.model("Waiver", waiverSchema);

--- a/src/hooks/useWaiverStatus.ts
+++ b/src/hooks/useWaiverStatus.ts
@@ -3,31 +3,32 @@
 import { useEffect, useState } from "react";
 import { AppEvent, isUpcomingEvent } from "@/data/events";
 
-export type ApiWaiverStatus = "complete" | "incomplete";
-
 type WaiverStatusResponse = {
-  status?: ApiWaiverStatus;
+  completedSchools?: string[];
   error?: string;
 };
 
-export function applyWaiverStatusToEvent(event: AppEvent, waiverStatus: ApiWaiverStatus): AppEvent {
-  if (!isUpcomingEvent(event)) {
+export function applyWaiverStatusToEvent(event: AppEvent, completedSchools: string[]): AppEvent {
+  if (!isUpcomingEvent(event) || !event.location) {
     return event;
   }
 
+  const normalizedEventSchool = normalizeSchool(event.location);
+  const hasCompletedWaiver = completedSchools.includes(normalizedEventSchool);
+
   return {
     ...event,
-    waiverSigned: waiverStatus === "complete",
+    waiverSigned: hasCompletedWaiver,
   };
 }
 
 export function useWaiverStatus(enabled: boolean) {
-  const [status, setStatus] = useState<ApiWaiverStatus | null>(null);
+  const [completedSchools, setCompletedSchools] = useState<string[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!enabled) {
-      setStatus(null);
+      setCompletedSchools(null);
       setError(null);
       return;
     }
@@ -41,7 +42,7 @@ export function useWaiverStatus(enabled: boolean) {
         if (!response.ok) {
           if (response.status === 401) {
             if (!cancelled) {
-              setStatus(null);
+              setCompletedSchools(null);
               setError("unauthorized");
             }
             return;
@@ -53,9 +54,9 @@ export function useWaiverStatus(enabled: boolean) {
 
         const data = (await response.json()) as WaiverStatusResponse;
 
-        if (data.status === "complete" || data.status === "incomplete") {
+        if (Array.isArray(data.completedSchools)) {
           if (!cancelled) {
-            setStatus(data.status);
+            setCompletedSchools(data.completedSchools);
             setError(null);
           }
           return;
@@ -64,7 +65,7 @@ export function useWaiverStatus(enabled: boolean) {
         throw new Error("Invalid waiver status response");
       } catch (err) {
         if (!cancelled) {
-          setStatus(null);
+          setCompletedSchools(null);
           setError(err instanceof Error ? err.message : "Failed to load waiver status");
         }
       }
@@ -77,5 +78,9 @@ export function useWaiverStatus(enabled: boolean) {
     };
   }, [enabled]);
 
-  return { status, error };
+  return { completedSchools, error };
+}
+
+function normalizeSchool(school: string): string {
+  return school.toLowerCase().trim().replace(/\./g, "").replace(/\s+/g, " ");
 }

--- a/src/hooks/useWaiverStatus.ts
+++ b/src/hooks/useWaiverStatus.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AppEvent, isUpcomingEvent } from "@/data/events";
+
+export type ApiWaiverStatus = "complete" | "incomplete";
+
+type WaiverStatusResponse = {
+  status?: ApiWaiverStatus;
+  error?: string;
+};
+
+export function applyWaiverStatusToEvent(event: AppEvent, waiverStatus: ApiWaiverStatus): AppEvent {
+  if (!isUpcomingEvent(event)) {
+    return event;
+  }
+
+  return {
+    ...event,
+    waiverSigned: waiverStatus === "complete",
+  };
+}
+
+export function useWaiverStatus(enabled: boolean) {
+  const [status, setStatus] = useState<ApiWaiverStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadWaiverStatus = async () => {
+      try {
+        const response = await fetch("/api/me/waiver-status", { cache: "no-store" });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            if (!cancelled) {
+              setStatus(null);
+              setError("unauthorized");
+            }
+            return;
+          }
+
+          const failed = (await response.json().catch(() => null)) as WaiverStatusResponse | null;
+          throw new Error(failed?.error || "Failed to load waiver status");
+        }
+
+        const data = (await response.json()) as WaiverStatusResponse;
+
+        if (data.status === "complete" || data.status === "incomplete") {
+          if (!cancelled) {
+            setStatus(data.status);
+            setError(null);
+          }
+          return;
+        }
+
+        throw new Error("Invalid waiver status response");
+      } catch (err) {
+        if (!cancelled) {
+          setStatus(null);
+          setError(err instanceof Error ? err.message : "Failed to load waiver status");
+        }
+      }
+    };
+
+    loadWaiverStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { status, error };
+}


### PR DESCRIPTION
## Developer: Lorinc Heutchy

Closes #7 

### Pull Request Summary

Implemented Jotform waiver status integration end-to-end for the volunteer event-card experience.
The backend now exposes GET /api/me/waiver-status, which checks Clerk-authenticated user identity, reads/writes waiver status in MongoDB, and falls back to Jotform submissions matching by email when cache is missing/stale.
Frontend volunteer event-card views now consume this status instead of relying only on hardcoded waiver placeholders.

### Modifications

route.ts
- Created new API route to:
  -validate required Jotform env vars
  -authenticate current user via Clerk
  -load app user from MongoDB
  -check cached waiver status in waivers
  -fetch Jotform submissions and match by normalized email when needed
  -upsert waiver record and return status response

Waiver.ts
-Created new Mongoose model/collection for cached waiver status metadata (status, waiverSubmissionId, waiverLastCheckedAt, etc.).

useWaiverStatus.ts
-Added client hook to fetch /api/me/waiver-status and helper mapping logic to convert API waiver status into card status display state.

VolunteerEventsPage.tsx
-Wired volunteer event-card data to use fetched waiver status mapping.

page.tsx
-Wired calendar volunteer event cards to use fetched waiver status mapping.

### Testing Considerations

I tested on my account that the waiver status is incomplete for everything and that Mongo updated the Waiver table with my information

Reviewer should verify:
-End-to-end complete path with a known account/email that exists in Jotform submissions.
-End-to-end incomplete path with a non-matching account/email.
-Mongo waivers collection updates correctly after endpoint calls.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast