### PR TITLE
Removed green arrow button

### DIFF
--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -46,9 +46,10 @@ function DateRangeControl({
           setEnd(fromInputLocal(e.target.value));
         }}
       />
-      <button type="button" className={styles.goButton} aria-label="Apply date range">
+
+      {/*<button type="button" className={styles.goButton} aria-label="Apply date range">
         →
-      </button>
+      </button>*/}
     </div>
   );
 }

--- a/src/components/VolunteerEventsPage.tsx
+++ b/src/components/VolunteerEventsPage.tsx
@@ -46,10 +46,6 @@ function DateRangeControl({
           setEnd(fromInputLocal(e.target.value));
         }}
       />
-
-      {/*<button type="button" className={styles.goButton} aria-label="Apply date range">
-        →
-      </button>*/}
     </div>
   );
 }

--- a/src/styles/VolunteerEventsPage.module.css
+++ b/src/styles/VolunteerEventsPage.module.css
@@ -22,7 +22,7 @@
 }
 
 .dateInput {
-  width: 135px;
+  width: 145px;
   height: 38px;
   border: 2px solid #8aa9d6;
   padding: 0 10px;

--- a/src/styles/VolunteerEventsPage.module.css
+++ b/src/styles/VolunteerEventsPage.module.css
@@ -32,7 +32,7 @@
 }
 
 .dateInput:last-of-type {
-  border-radius: 0;
+  border-radius: 0 6px 6px 0;
 }
 
 .toBox {


### PR DESCRIPTION


## Developer: Vinayak Kohli

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Removed the green "go" arrow on the date containers in the my events page. 

After removing the green arrow the right side of the date container was squared off, I modified it so the entire date container is rounded.

I also widended the date container by 10 px the calendar icon was slightly covering the start range date


### Modifications

src/styles/VolunteerEventsPage.module.css
- changed border radius for the date container to result in it being rounded as per the screenshot
 src/components/VolunteerEventsPage.tsx
- Removed green arrow button

### Testing Considerations

- Tested date container change still filtering out events on carousel correctly

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
Before date container widening - green arrow removed 
<img width="3314" height="1902" alt="image" src="https://github.com/user-attachments/assets/f1714b96-d207-44b7-85c5-0e4978cfb3e7" />

After widening the date container - green arrow still removed
![Uploading Screenshot 2026-05-13 at 7.56.13 PM.png…]()

