### PR TITLE
Rounded buttons on create event pop-up

### DIFF
--- a/src/components/CreateEventModal.tsx
+++ b/src/components/CreateEventModal.tsx
@@ -196,7 +196,7 @@ export default function CreateEventModal({ isOpen, onClose, onSuccess }: CreateE
             />
 
             <div className={styles.imageButtonRow}>
-              <button type="button" className={styles.imageButton} onClick={() => fileInputRef.current?.click()}>
+              <button type="button" className={styles.actionButton} onClick={() => fileInputRef.current?.click()}>
                 {draft.imageUrl ? "Change Image" : "Upload Image"}
               </button>
 

--- a/src/styles/CreateEventModal.module.css
+++ b/src/styles/CreateEventModal.module.css
@@ -125,11 +125,12 @@
   font-size: 19px;
   cursor: pointer;
   box-sizing: border-box;
+  transition: background-color 0.2s ease;
 }
 
 .imageButton:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
+  background-color: #cfe0b7;
+  box-shadow: none;
 }
 
 .imageButton:active {
@@ -166,11 +167,12 @@
   font-size: 25px;
   cursor: pointer;
   box-sizing: border-box;
+  transition: background-color 0.2s ease;
 }
 
 .actionButton:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
+  background-color: #cfe0b7;
+  box-shadow: none;
 }
 
 .actionButton:active {

--- a/src/styles/CreateEventModal.module.css
+++ b/src/styles/CreateEventModal.module.css
@@ -160,7 +160,7 @@
   border: 1px solid #307433;
   background: #dcf9c9;
   color: #568264;
-  border-radius: 2px;
+  border-radius: 8px;
   padding: 8px 16px;
   font-weight: 700;
   font-size: 25px;


### PR DESCRIPTION
## Developer: Vinayak Kohli @vkohli244 

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Changed button styling and hover shadow on create event pop-up visible as an admin.

### Modifications

src/styles/CreateEventModal.module.css
- changed styling for .actionButton to have rounded corners consistent with the rest of green buttons across the site
- changed hover animation from translating the button up a pixel to a change in opacity

src/styles/CreateEventModal
- changed Upload image button styling class to .actionButton

### Testing Considerations

- Verified functionality of buttons post styling change

### Pull Request Checklist

- [] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="592" height="633" alt="Screenshot 2026-05-15 at 3 30 13 PM" src="https://github.com/user-attachments/assets/a41a2b94-b885-4c84-862e-d6719c1d32d7" />


Example of button in hover state, this is consistent across all buttons.
<img width="1186" height="1268" alt="image" src="https://github.com/user-attachments/assets/031a6b1e-69ac-4735-b1e1-aca976c82e6a" />

