### PR TITLE
Feat: on hover, the original card text goes away

### DIFF
--- a/src/styles/VolunteerEventsPage.module.css
+++ b/src/styles/VolunteerEventsPage.module.css
@@ -120,6 +120,7 @@
   justify-content: center;
   padding: 14px;
   color: white;
+  transition: opacity 150ms ease;
 }
 
 .cardDate {
@@ -254,6 +255,10 @@
 .cardHoverEnabled:hover .hoverPanel {
   opacity: 1;
   pointer-events: auto;
+}
+
+.cardHoverEnabled:hover .cardContent {
+  opacity: 0;
 }
 
 .cardHoverEnabled:hover .statusWrap {


### PR DESCRIPTION
## Developer: Vinayak @vkohli244 

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

On hover over an event card on the calendar page, the original text of the card was showing very faintly under the transparent pop-up text. 

### Modifications

src/styles/VolunteerEventsPage.module.css
- modified the hover state of .cardHoverEnabled to set opacity of card content to 0.

### Testing Considerations



### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

Before the fix: 
<img width="580" height="638" alt="Screenshot 2026-05-15 at 4 01 44 PM" src="https://github.com/user-attachments/assets/ab164cb4-e7a7-48d6-9704-a55525b1f47d" />

After the fix: 
<img width="541" height="626" alt="Screenshot 2026-05-15 at 4 02 41 PM" src="https://github.com/user-attachments/assets/8fe8eaa2-b486-4dda-a0ce-c3205d76b437" />

