### PR TITLE
Consolidated buttons to only include view event button

### DIFF
--- a/src/components/AdminEventCard.tsx
+++ b/src/components/AdminEventCard.tsx
@@ -63,10 +63,6 @@ export default function AdminEventCard({ event }: { event: AppEvent }) {
           <div className={styles.hoverText}>{event.location}</div>
 
           <div className={styles.hoverButtons}>
-            <button type="button" className={styles.hoverBtnLight} onClick={() => router.push(eventHref)}>
-              Edit Event
-            </button>
-
             <button type="button" className={styles.hoverBtnDark} onClick={() => router.push(eventHref)}>
               {isPast ? "Event Report" : "View Event Info"}
             </button>


### PR DESCRIPTION
## Developer: Vinayak Kohli

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Consolidated event card buttons since they led to the same page. Previously, there were two buttons that led to the same page allowing an admin to view and edit event details. Now there is only one button (View event)

### Modifications

src/components/AdminEventCard.tsx
- deleted  edit event button

### Testing Considerations

- Everything works great!

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="747" height="389" alt="Screenshot 2026-05-20 at 7 08 42 PM" src="https://github.com/user-attachments/assets/19e6c55f-0c1f-4e05-8770-0ebbab7a2fc1" />

<img width="743" height="424" alt="Screenshot 2026-05-20 at 7 09 04 PM" src="https://github.com/user-attachments/assets/b621e0ec-d35d-4ef3-860b-a33ad785c101" />
