### PR TITLE
fix: phone number styling consistent w/ other fields

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -147,15 +147,18 @@ export default function AccountPage() {
               <div className={styles.shortRow}>
                 <div className={styles.fieldGroup}>
                   <label className={styles.label}>Phone Number</label>
-                  <input
-                    className={styles.input}
-                    type="text"
-                    name="phoneNumber"
-                    value={formData.phoneNumber}
-                    onChange={handleChange}
-                    disabled={!isEditing}
-                    placeholder={"(XXX) XXX-XXXX"}
-                  />
+                  {isEditing ? (
+                    <input
+                      className={styles.input}
+                      type="text"
+                      name="phoneNumber"
+                      value={formData.phoneNumber}
+                      onChange={handleChange}
+                      placeholder={"(XXX) XXX-XXXX"}
+                    />
+                  ) : (
+                    <div className={styles.inputReadOnly}>{formData.phoneNumber || "—"}</div>
+                  )}
                 </div>
 
                 <div className={styles.compactFieldGroup}>


### PR DESCRIPTION
## Developer: {Full Name}

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Changed styling of phone number field to be consistent with the rest of the account page

### Modifications

src/app/account/page.tsx
- changed the class for phone number to use the read only isediting? class

### Testing Considerations
- Tested styling of fields after clicking edit information

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencastw
<img width="878" height="750" alt="Screenshot 2026-05-20 at 7 25 39 PM" src="https://github.com/user-attachments/assets/d2b51d16-5560-4cff-904d-45d34cb89a7f" />


<img width="945" height="814" alt="Screenshot 2026-05-20 at 7 25 46 PM" src="https://github.com/user-attachments/assets/816301f0-3231-4dff-b7ce-b5fcd2588bc7" />


{put screenshots of your change, or even better a screencast displaying the functionality}
